### PR TITLE
feat: implement Bacon's encoding module

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -132,7 +132,7 @@ const baseMenuItems = [
   { name: 'cryptotron-autokey', label: 'Autokey', category: 'Polyalphabetic Ciphers' },
   { name: 'cryptotron-beaufort', label: 'Beaufort', category: 'Polyalphabetic Ciphers' },
   { name: 'cryptotron-vigenere', label: 'Vigenère', category: 'Polyalphabetic Ciphers' },
-  { name: 'cryptotron-bacon', label: "Bacon's", category: 'Steganography Ciphers' },
+  { name: 'cryptotron-bacon', label: "Bacon's Encoding", category: 'Steganography' },
   { name: 'cryptotron-rail-fence', label: 'Rail-Fence', category: 'Transposition Ciphers' },
   { name: 'cryptotron-columnar', label: 'Columnar', category: 'Transposition Ciphers' },
 ]

--- a/src/App.vue
+++ b/src/App.vue
@@ -132,6 +132,7 @@ const baseMenuItems = [
   { name: 'cryptotron-autokey', label: 'Autokey', category: 'Polyalphabetic Ciphers' },
   { name: 'cryptotron-beaufort', label: 'Beaufort', category: 'Polyalphabetic Ciphers' },
   { name: 'cryptotron-vigenere', label: 'Vigenère', category: 'Polyalphabetic Ciphers' },
+  { name: 'cryptotron-bacon', label: "Bacon's", category: 'Steganography Ciphers' },
   { name: 'cryptotron-rail-fence', label: 'Rail-Fence', category: 'Transposition Ciphers' },
   { name: 'cryptotron-columnar', label: 'Columnar', category: 'Transposition Ciphers' },
 ]

--- a/src/components/CipherCard.vue
+++ b/src/components/CipherCard.vue
@@ -246,8 +246,8 @@ const isKeyMode = ref(false)
 const handleKeydown = (e: KeyboardEvent) => {
   if (e.defaultPrevented) return
 
-  // Ignore shortcuts if Ctrl, Meta (Cmd), or Alt are pressed
-  if (e.ctrlKey || e.metaKey || e.altKey) return
+  // Ignore shortcuts if any modifier key is pressed
+  if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return
 
   const isInput = ['INPUT', 'TEXTAREA'].includes((e.target as HTMLElement).tagName)
   const isKeyInput = (e.target as HTMLElement).classList.contains('cipher-input')

--- a/src/components/CipherCard.vue
+++ b/src/components/CipherCard.vue
@@ -67,6 +67,7 @@
             <div class="control-group">
               <label class="control-label">Input Text:</label>
               <textarea
+                ref="encryptInputField"
                 v-model="encryptInput"
                 placeholder="Enter text to encrypt..."
                 class="cipher-textarea"
@@ -103,6 +104,7 @@
             <div class="control-group">
               <label class="control-label">Input Text:</label>
               <textarea
+                ref="decryptInputField"
                 v-model="decryptInput"
                 placeholder="Enter text to decrypt..."
                 class="cipher-textarea"
@@ -194,6 +196,8 @@ const root = ref<HTMLElement | null>(null)
 const theoryPanel = ref<HTMLElement | null>(null)
 const encryptPanel = ref<HTMLElement | null>(null)
 const decryptPanel = ref<HTMLElement | null>(null)
+const encryptInputField = ref<HTMLTextAreaElement | null>(null)
+const decryptInputField = ref<HTMLTextAreaElement | null>(null)
 
 const getPanel = (tabId: string) => {
   if (tabId === 'theory') return theoryPanel.value
@@ -283,13 +287,13 @@ const handleKeydown = (e: KeyboardEvent) => {
   if (!isInsertMode.value) {
     switch (key) {
       case 'i': {
-        const panel = getPanel(cipherActiveTab.value)
-        const textarea = panel?.querySelector('textarea') as HTMLTextAreaElement
-        if (textarea) {
+        const target =
+          cipherActiveTab.value === 'encrypt' ? encryptInputField.value : decryptInputField.value
+        if (target) {
           e.preventDefault()
           isInsertMode.value = true
           isKeyMode.value = false
-          setTimeout(() => textarea.focus(), 0)
+          setTimeout(() => target.focus(), 0)
         }
         break
       }

--- a/src/components/CipherCard.vue
+++ b/src/components/CipherCard.vue
@@ -179,6 +179,10 @@ const props = defineProps({
     type: Function,
     required: false,
   },
+  normalModeKeyHandler: {
+    type: Function,
+    required: false,
+  },
 })
 
 const emit = defineEmits<{
@@ -325,6 +329,12 @@ const handleKeydown = (e: KeyboardEvent) => {
         break
       case 'y':
         yankOutput()
+        break
+      default:
+        if (props.normalModeKeyHandler) {
+          const handled = props.normalModeKeyHandler(key, cipherActiveTab.value)
+          if (handled) e.preventDefault()
+        }
         break
     }
   }

--- a/src/components/CipherCard.vue
+++ b/src/components/CipherCard.vue
@@ -175,6 +175,10 @@ const props = defineProps({
     type: Function,
     required: false,
   },
+  encryptOutputOverride: {
+    type: Function,
+    required: false,
+  },
 })
 
 const emit = defineEmits<{
@@ -393,7 +397,11 @@ const showYankedTooltip = ref(false)
 let crackTimer: ReturnType<typeof setTimeout> | null = null
 
 const yankOutput = () => {
-  const output = cipherActiveTab.value === 'encrypt' ? encryptOutput.value : decryptOutput.value
+  const overriddenEncryptOutput = props.encryptOutputOverride?.()
+  const output =
+    cipherActiveTab.value === 'encrypt'
+      ? (overriddenEncryptOutput ?? encryptOutput.value)
+      : decryptOutput.value
   if (!output) return
 
   navigator.clipboard

--- a/src/components/CipherCard.vue
+++ b/src/components/CipherCard.vue
@@ -152,6 +152,7 @@
 
 <script setup lang="ts">
 import { nextTick, onMounted, onUnmounted, ref } from 'vue'
+import type { PropType } from 'vue'
 import CipherOutput from './CipherOutput.vue'
 import ScanLine from './ScanLine.vue'
 import CyberIcon from './icons/CyberIcon.vue'
@@ -178,11 +179,11 @@ const props = defineProps({
     required: false,
   },
   encryptOutputOverride: {
-    type: Function,
+    type: Function as PropType<(() => string) | undefined>,
     required: false,
   },
   normalModeKeyHandler: {
-    type: Function,
+    type: Function as PropType<((key: string, activeTab: string) => boolean) | undefined>,
     required: false,
   },
 })

--- a/src/components/CipherCard.vue
+++ b/src/components/CipherCard.vue
@@ -83,7 +83,13 @@
               <span>{{ encryptError }}</span>
             </div>
 
-            <CipherOutput label="Output" :text="encryptOutput" />
+            <slot
+              name="encryptOutput"
+              :text="encryptOutput"
+              :label="'Output'"
+            >
+              <CipherOutput label="Output" :text="encryptOutput" />
+            </slot>
           </div>
         </div>
 
@@ -128,7 +134,13 @@
               <span>{{ decryptError }}</span>
             </div>
 
-            <CipherOutput label="Output" :text="decryptOutput" />
+            <slot
+              name="decryptOutput"
+              :text="decryptOutput"
+              :label="'Output'"
+            >
+              <CipherOutput label="Output" :text="decryptOutput" />
+            </slot>
           </div>
         </div>
       </div>

--- a/src/components/CipherCard.vue
+++ b/src/components/CipherCard.vue
@@ -289,7 +289,11 @@ const handleKeydown = (e: KeyboardEvent) => {
     switch (key) {
       case 'i': {
         const target =
-          cipherActiveTab.value === 'encrypt' ? encryptInputField.value : decryptInputField.value
+          cipherActiveTab.value === 'encrypt'
+            ? encryptInputField.value
+            : cipherActiveTab.value === 'decrypt'
+              ? decryptInputField.value
+              : null
         if (target) {
           e.preventDefault()
           isInsertMode.value = true

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -67,5 +67,10 @@ export default (parentRouteName?: string) => {
       path: `${rootPath}playfair`,
       component: () => import('@/views/PlayfairView.vue'),
     },
+    {
+      name: 'cryptotron-bacon',
+      path: `${rootPath}bacon`,
+      component: () => import('@/views/BaconView.vue'),
+    },
   ]
 }

--- a/src/utils/steganography.ts
+++ b/src/utils/steganography.ts
@@ -1,0 +1,96 @@
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+
+export type BaconType = 'a' | 'b'
+
+export interface StyledChar {
+  char: string
+  type: BaconType
+}
+
+const encodeChar = (char: string): string => {
+  const idx = ALPHABET.indexOf(char)
+  return idx.toString(2).padStart(5, '0').replace(/0/g, 'a').replace(/1/g, 'b')
+}
+
+const decodeChunk = (chunk: string): string => {
+  const binary = chunk.replace(/a/g, '0').replace(/b/g, '1')
+  const idx = Number.parseInt(binary, 2)
+  return ALPHABET[idx] ?? ''
+}
+
+export const baconEncoder = (secret: string, cover: string): StyledChar[] => {
+  const cleaned = secret.toUpperCase().replace(/[^A-Z]/g, '')
+  const bits = [...cleaned].map(encodeChar).join('')
+
+  const alphaCount = [...cover].filter((c) => /[A-Za-z]/.test(c)).length
+  if (alphaCount < bits.length) {
+    throw new Error(`Cover text too short: need ${bits.length} letters, got ${alphaCount}.`)
+  }
+
+  let bitIndex = 0
+  return [...cover].map((char) => {
+    if (!/[A-Za-z]/.test(char) || bitIndex >= bits.length) {
+      return { char, type: 'a' }
+    }
+
+    const type = bits[bitIndex] as BaconType
+    bitIndex += 1
+    return { char, type }
+  })
+}
+
+export const toHtmlSnippet = (styled: StyledChar[]): string => {
+  const spans = styled
+    .map(({ char, type }) => `<span class="b-${type}">${escapeHtml(char)}</span>`)
+    .join('')
+
+  return `<style>\n.b-a{font-weight:400;color:var(--text-primary);}\n.b-b{font-weight:700;color:var(--neon-green);text-shadow:0 0 5px var(--neon-green);}\n</style>\n<p>${spans}</p>`
+}
+
+export const toMarkdown = (styled: StyledChar[]): string =>
+  styled.map(({ char, type }) => (type === 'b' ? `**${char}**` : char)).join('')
+
+export const baconDecoder = (styledInput: string): string => {
+  const normalized = styledInput
+    .replace(/\*\*([^*]+)\*\*/g, (_, inner: string) => `[[B]]${inner}[[/B]]`)
+    .replace(/<\s*strong\b[^>]*>(.*?)<\s*\/\s*strong>/gim, '[[B]]$1[[/B]]')
+    .replace(/<\s*b\b[^>]*>(.*?)<\s*\/\s*b>/gim, '[[B]]$1[[/B]]')
+    .replace(/<\s*span\b[^>]*class=["'][^"']*b-b[^"']*["'][^>]*>(.*?)<\s*\/\s*span>/gim, '[[B]]$1[[/B]]')
+    .replace(/<[^>]+>/g, '')
+
+  const bits: BaconType[] = []
+  let inBold = false
+
+  for (let i = 0; i < normalized.length; i += 1) {
+    if (normalized.startsWith('[[B]]', i)) {
+      inBold = true
+      i += 4
+      continue
+    }
+    if (normalized.startsWith('[[/B]]', i)) {
+      inBold = false
+      i += 5
+      continue
+    }
+
+    const char = normalized[i]
+    if (/[A-Za-z]/.test(char)) {
+      bits.push(inBold ? 'b' : 'a')
+    }
+  }
+
+  let output = ''
+  for (let i = 0; i + 4 < bits.length; i += 5) {
+    output += decodeChunk(bits.slice(i, i + 5).join(''))
+  }
+
+  return output
+}
+
+const escapeHtml = (input: string): string =>
+  input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')

--- a/src/utils/steganography.ts
+++ b/src/utils/steganography.ts
@@ -5,6 +5,7 @@ export type BaconType = 'a' | 'b'
 export interface StyledChar {
   char: string
   type: BaconType
+  carriesBit: boolean
 }
 
 const encodeChar = (char: string): string => {
@@ -30,38 +31,56 @@ export const baconEncoder = (secret: string, cover: string): StyledChar[] => {
   let bitIndex = 0
   return [...cover].map((char) => {
     if (!/[A-Za-z]/.test(char) || bitIndex >= bits.length) {
-      return { char, type: 'a' }
+      return { char, type: 'a', carriesBit: false }
     }
 
     const type = bits[bitIndex] as BaconType
     bitIndex += 1
-    return { char, type }
+    return { char, type, carriesBit: true }
   })
 }
 
 export const toHtmlSnippet = (styled: StyledChar[]): string => {
+  const carrierCount = styled.filter(({ carriesBit }) => carriesBit).length
   const spans = styled
-    .map(({ char, type }) => `<span class="b-${type}">${escapeHtml(char)}</span>`)
+    .map(({ char, type, carriesBit }) =>
+      carriesBit
+        ? `<span class="b-${type}">${escapeHtml(char)}</span>`
+        : `<span class="b-n">${escapeHtml(char)}</span>`,
+    )
     .join('')
 
-  return `<style>\n.b-a{font-weight:400;color:#e5e7eb;}\n.b-b{font-weight:700;color:#00ff41;text-shadow:0 0 5px #00ff41;}\n</style>\n<p>${spans}</p>`
+  return `<style>\n.b-a{font-weight:400;color:#e5e7eb;}\n.b-b{font-weight:700;color:#00ff41;text-shadow:0 0 5px #00ff41;}\n.b-n{font-weight:400;color:#e5e7eb;}\n</style>\n<p data-bacon-carriers="${carrierCount}">${spans}</p>`
 }
 
-export const toMarkdown = (styled: StyledChar[]): string =>
-  styled.map(({ char, type }) => (type === 'b' ? `**${char}**` : char)).join('')
+export const toMarkdown = (styled: StyledChar[]): string => {
+  const carrierCount = styled.filter(({ carriesBit }) => carriesBit).length
+  const markdownBody = styled.map(({ char, type }) => (type === 'b' ? `**${char}**` : char)).join('')
+  return `<!--BACON:CARRIERS=${carrierCount}-->\n${markdownBody}`
+}
 
 export const baconDecoder = (styledInput: string): string => {
-  const normalized = styledInput
-    .replace(/<\s*style\b[^>]*>[\s\S]*?<\s*\/\s*style>/gim, '')
-    .replace(/<\s*script\b[^>]*>[\s\S]*?<\s*\/\s*script>/gim, '')
-    .replace(/\*\*([^*]+)\*\*/g, (_, inner: string) => `[[B]]${inner}[[/B]]`)
-    .replace(/<\s*strong\b[^>]*>(.*?)<\s*\/\s*strong>/gim, '[[B]]$1[[/B]]')
-    .replace(/<\s*b\b[^>]*>(.*?)<\s*\/\s*b>/gim, '[[B]]$1[[/B]]')
-    .replace(/<\s*span\b[^>]*class=["'][^"']*b-b[^"']*["'][^>]*>(.*?)<\s*\/\s*span>/gim, '[[B]]$1[[/B]]')
-    .replace(/<[^>]+>/g, '')
+  const carrierCountMatch =
+    styledInput.match(/data-bacon-carriers=["'](\d+)["']/i) ?? styledInput.match(/<!--\s*BACON:CARRIERS=(\d+)\s*-->/i)
+  const carrierCount = carrierCountMatch ? Number.parseInt(carrierCountMatch[1], 10) : null
+
+  const normalized = decodeHtmlEntities(
+    styledInput
+      .replace(/<\s*style\b[^>]*>[\s\S]*?<\s*\/\s*style>/gim, '')
+      .replace(/<\s*script\b[^>]*>[\s\S]*?<\s*\/\s*script>/gim, '')
+      .replace(/\*\*([^*]+)\*\*/g, (_, inner: string) => `[[B]]${inner}[[/B]]`)
+      .replace(/<\s*strong\b[^>]*>(.*?)<\s*\/\s*strong>/gim, '[[B]]$1[[/B]]')
+      .replace(/<\s*b\b[^>]*>(.*?)<\s*\/\s*b>/gim, '[[B]]$1[[/B]]')
+      .replace(/<\s*span\b[^>]*class=["'][^"']*b-b[^"']*["'][^>]*>(.*?)<\s*\/\s*span>/gim, '[[B]]$1[[/B]]')
+      .replace(/<\s*span\b[^>]*class=["'][^"']*b-a[^"']*["'][^>]*>(.*?)<\s*\/\s*span>/gim, '[[A]]$1[[/A]]')
+      .replace(/<\s*span\b[^>]*class=["'][^"']*b-n[^"']*["'][^>]*>(.*?)<\s*\/\s*span>/gim, '$1')
+      .replace(/<[^>]+>/g, ''),
+  )
 
   const bits: BaconType[] = []
   let inBold = false
+  let inExplicitA = false
+  let consumedCarriers = 0
 
   for (let i = 0; i < normalized.length; i += 1) {
     if (normalized.startsWith('[[B]]', i)) {
@@ -74,10 +93,25 @@ export const baconDecoder = (styledInput: string): string => {
       i += 5
       continue
     }
+    if (normalized.startsWith('[[A]]', i)) {
+      inExplicitA = true
+      i += 4
+      continue
+    }
+    if (normalized.startsWith('[[/A]]', i)) {
+      inExplicitA = false
+      i += 5
+      continue
+    }
+
+    if (carrierCount !== null && consumedCarriers >= carrierCount) {
+      continue
+    }
 
     const char = normalized[i]
-    if (/[A-Za-z]/.test(char)) {
+    if (/[A-Za-z]/.test(char) && (inBold || inExplicitA || carrierCount !== null)) {
       bits.push(inBold ? 'b' : 'a')
+      consumedCarriers += 1
     }
   }
 
@@ -88,6 +122,14 @@ export const baconDecoder = (styledInput: string): string => {
 
   return output
 }
+
+const decodeHtmlEntities = (input: string): string =>
+  input
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
 
 const escapeHtml = (input: string): string =>
   input

--- a/src/utils/steganography.ts
+++ b/src/utils/steganography.ts
@@ -130,6 +130,10 @@ const decodeHtmlEntities = (input: string): string =>
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex: string) => String.fromCodePoint(Number.parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec: string) => String.fromCodePoint(Number.parseInt(dec, 10)))
 
 const escapeHtml = (input: string): string =>
   input

--- a/src/utils/steganography.ts
+++ b/src/utils/steganography.ts
@@ -44,7 +44,7 @@ export const toHtmlSnippet = (styled: StyledChar[]): string => {
     .map(({ char, type }) => `<span class="b-${type}">${escapeHtml(char)}</span>`)
     .join('')
 
-  return `<style>\n.b-a{font-weight:400;color:var(--text-primary);}\n.b-b{font-weight:700;color:var(--neon-green);text-shadow:0 0 5px var(--neon-green);}\n</style>\n<p>${spans}</p>`
+  return `<style>\n.b-a{font-weight:400;color:#e5e7eb;}\n.b-b{font-weight:700;color:#00ff41;text-shadow:0 0 5px #00ff41;}\n</style>\n<p>${spans}</p>`
 }
 
 export const toMarkdown = (styled: StyledChar[]): string =>

--- a/src/utils/steganography.ts
+++ b/src/utils/steganography.ts
@@ -52,6 +52,8 @@ export const toMarkdown = (styled: StyledChar[]): string =>
 
 export const baconDecoder = (styledInput: string): string => {
   const normalized = styledInput
+    .replace(/<\s*style\b[^>]*>[\s\S]*?<\s*\/\s*style>/gim, '')
+    .replace(/<\s*script\b[^>]*>[\s\S]*?<\s*\/\s*script>/gim, '')
     .replace(/\*\*([^*]+)\*\*/g, (_, inner: string) => `[[B]]${inner}[[/B]]`)
     .replace(/<\s*strong\b[^>]*>(.*?)<\s*\/\s*strong>/gim, '[[B]]$1[[/B]]')
     .replace(/<\s*b\b[^>]*>(.*?)<\s*\/\s*b>/gim, '[[B]]$1[[/B]]')

--- a/src/views/BaconView.vue
+++ b/src/views/BaconView.vue
@@ -77,14 +77,40 @@ onBeforeUnmount(() => {
       <button :class="{ active: activeTab === 'extract' }" @click="activeTab = 'extract'">Extract</button>
     </div>
 
-    <div v-if="activeTab === 'theory'" class="panel">
+    <div v-if="activeTab === 'theory'" class="panel theory-content">
       <p>
-        Bacon's Cipher maps each plaintext letter (A-Z) into a 5-symbol sequence of a/b, then hides those
-        symbols in visible typography changes across a cover text.
+        <strong>Bacon's Cipher</strong> is a steganographic technique from the early 1600s, credited to Francis Bacon.
+        Instead of scrambling letters like Caesar or Vigenère, it hides a message in plain sight by changing style.
       </p>
       <p>
-        In this implementation, normal letters are Type A and emphasized letters are Type B. Five styled letters
-        decode to one secret character.
+        The modern variant used here maps each secret letter A-Z to a five-character pattern made of <code>a</code> and
+        <code>b</code>. You can think of <code>a</code> as binary 0 and <code>b</code> as binary 1. Since five bits can represent
+        32 values, we have enough room to encode all 26 letters.
+      </p>
+      <p>
+        In Cryptotron, each alphabetic character in the cover text carries one bit:
+      </p>
+      <ul>
+        <li><strong>Type A</strong> (normal weight) = <code>a</code> = 0</li>
+        <li><strong>Type B</strong> (bright emphasized text) = <code>b</code> = 1</li>
+      </ul>
+      <p>
+        After five styled letters, the decoder reads one hidden character. Spaces and punctuation are preserved in the
+        cover text but do not consume bits.
+      </p>
+      <p>
+        <strong>Example:</strong> The letter <code>H</code> is index 7 in A=0 indexing, binary <code>00111</code>, which becomes
+        <code>aabbb</code>. If your cover starts with "There...", the first five alphabetic letters would be styled as:
+        normal, normal, bold, bold, bold.
+      </p>
+      <p>
+        To hide a full message, the app concatenates these five-bit groups and applies them left-to-right over the
+        cover text. To extract, it reads styling back into bits, chunks them by five, and maps each chunk to a letter.
+      </p>
+      <p>
+        Use this when you want subtle message hiding rather than cryptographic strength. Anyone who notices the
+        style pattern can decode it, so the real security comes from plausible cover text and not drawing attention to
+        the Type A/Type B distinction.
       </p>
     </div>
 
@@ -122,9 +148,35 @@ onBeforeUnmount(() => {
 .bacon-view { display: grid; gap: 1rem; }
 .tabs { display: flex; gap: 0.5rem; }
 button.active { border-color: var(--neon-green); color: var(--neon-green); }
-.panel { display: grid; gap: 0.6rem; }
+.panel {
+  display: grid;
+  gap: 0.75rem;
+  border: 1px solid var(--cryptotron-grid-color);
+  border-radius: 10px;
+  background: var(--panel-bg);
+  padding: 1rem;
+}
+
+.panel label {
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.theory-content ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.theory-content code {
+  font-family: var(--font-mono);
+  color: var(--neon-green);
+}
+
 .preview {
   border: 1px solid var(--cryptotron-grid-color);
+  background: color-mix(in srgb, var(--panel-bg) 85%, black 15%);
   padding: 1rem;
   border-radius: 8px;
   min-height: 5rem;
@@ -135,5 +187,17 @@ button.active { border-color: var(--neon-green); color: var(--neon-green); }
 .b-b { font-weight: 700; color: var(--neon-green); text-shadow: 0 0 5px var(--neon-green); }
 .preview.reveal .b-b { color: var(--neon-magenta); text-shadow: 0 0 8px var(--neon-magenta); }
 .error { color: #ff6b6b; }
-textarea { width: 100%; }
+textarea {
+  width: 100%;
+  border: 1px solid var(--cryptotron-grid-color);
+  border-radius: 8px;
+  background: var(--panel-bg);
+  color: var(--text-primary);
+  padding: 0.75rem;
+  resize: vertical;
+}
+
+textarea[readonly] {
+  opacity: 0.95;
+}
 </style>

--- a/src/views/BaconView.vue
+++ b/src/views/BaconView.vue
@@ -194,7 +194,7 @@ const baconDecrypt = (input: string) => {
         <textarea
           v-model="coverText"
           rows="6"
-          class="cipher-textarea"
+          class="cipher-textarea cipher-input"
           placeholder="Enter the visible carrier text..."
         />
       </div>

--- a/src/views/BaconView.vue
+++ b/src/views/BaconView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { baconDecoder, baconEncoder, toHtmlSnippet, toMarkdown, type StyledChar } from '@/utils/steganography'
 
 const activeTab = ref<'theory' | 'hide' | 'extract'>('theory')
@@ -12,7 +12,12 @@ const encodedInput = ref('')
 const preview = computed<StyledChar[]>(() => {
   try {
     return baconEncoder(secretMessage.value, coverText.value)
-  } catch {
+  } catch (error) {
+    console.error("Bacon encoder preview failed", {
+      error,
+      secretMessage: secretMessage.value,
+      coverText: coverText.value,
+    })
     return [...coverText.value].map((char) => ({ char, type: 'a' as const }))
   }
 })
@@ -25,22 +30,41 @@ const lengthError = computed(() =>
     : '',
 )
 
-const extracted = computed(() => baconDecoder(encodedInput.value))
+const extracted = computed(() => {
+  try {
+    return baconDecoder(encodedInput.value)
+  } catch (error) {
+    console.error('Bacon decoder extraction failed', {
+      error,
+      encodedInput: encodedInput.value,
+    })
+    return ''
+  }
+})
 
 const htmlExport = computed(() => toHtmlSnippet(preview.value))
 const markdownExport = computed(() => toMarkdown(preview.value))
 
 const handleHotkey = (event: KeyboardEvent) => {
   if (event.target instanceof HTMLTextAreaElement || event.target instanceof HTMLInputElement) return
+  if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return
 
   if (event.key === 'r') revealMode.value = !revealMode.value
   if (event.key === 'e') activeTab.value = 'hide'
   if (event.key === 'd') activeTab.value = 'extract'
 }
 
-if (typeof window !== 'undefined') {
-  window.addEventListener('keydown', handleHotkey)
-}
+onMounted(() => {
+  if (typeof window !== 'undefined') {
+    window.addEventListener('keydown', handleHotkey)
+  }
+})
+
+onBeforeUnmount(() => {
+  if (typeof window !== 'undefined') {
+    window.removeEventListener('keydown', handleHotkey)
+  }
+})
 </script>
 
 <template>

--- a/src/views/BaconView.vue
+++ b/src/views/BaconView.vue
@@ -1,19 +1,21 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import CipherCard from '@/components/CipherCard.vue'
+import { computed, ref } from 'vue'
 import { baconDecoder, baconEncoder, toHtmlSnippet, toMarkdown, type StyledChar } from '@/utils/steganography'
 
-const activeTab = ref<'theory' | 'hide' | 'extract'>('theory')
-const revealMode = ref(false)
-
+const baconCipherKey = ref({})
 const secretMessage = ref('')
 const coverText = ref('')
 const encodedInput = ref('')
+const revealMode = ref(false)
+const exportMode = ref<'html' | 'markdown'>('html')
+const copiedNotice = ref('')
 
 const preview = computed<StyledChar[]>(() => {
   try {
     return baconEncoder(secretMessage.value, coverText.value)
   } catch (error) {
-    console.error("Bacon encoder preview failed", {
+    console.error('Bacon encoder preview failed', {
       error,
       secretMessage: secretMessage.value,
       coverText: coverText.value,
@@ -44,129 +46,263 @@ const extracted = computed(() => {
 
 const htmlExport = computed(() => toHtmlSnippet(preview.value))
 const markdownExport = computed(() => toMarkdown(preview.value))
+const activeExport = computed(() => (exportMode.value === 'html' ? htmlExport.value : markdownExport.value))
 
-const handleHotkey = (event: KeyboardEvent) => {
-  if (event.target instanceof HTMLTextAreaElement || event.target instanceof HTMLInputElement) return
-  if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return
+const copyActiveExport = async () => {
+  if (!activeExport.value) return
 
-  if (event.key === 'r') revealMode.value = !revealMode.value
-  if (event.key === 'e') activeTab.value = 'hide'
-  if (event.key === 'd') activeTab.value = 'extract'
+  try {
+    await navigator.clipboard.writeText(activeExport.value)
+    copiedNotice.value = `${exportMode.value.toUpperCase()} copied`
+    setTimeout(() => {
+      copiedNotice.value = ''
+    }, 2000)
+  } catch (error) {
+    console.error('Failed to copy Bacon export', { error, exportMode: exportMode.value })
+    copiedNotice.value = 'Copy failed'
+    setTimeout(() => {
+      copiedNotice.value = ''
+    }, 2000)
+  }
 }
 
-onMounted(() => {
-  if (typeof window !== 'undefined') {
-    window.addEventListener('keydown', handleHotkey)
-  }
-})
-
-onBeforeUnmount(() => {
-  if (typeof window !== 'undefined') {
-    window.removeEventListener('keydown', handleHotkey)
-  }
-})
+const baconEncrypt = () => activeExport.value
+const baconDecrypt = () => extracted.value
 </script>
 
 <template>
-  <section class="bacon-view">
-    <h1>Bacon's Cipher</h1>
-
-    <div class="tabs">
-      <button :class="{ active: activeTab === 'theory' }" @click="activeTab = 'theory'">Theory</button>
-      <button :class="{ active: activeTab === 'hide' }" @click="activeTab = 'hide'">Hide</button>
-      <button :class="{ active: activeTab === 'extract' }" @click="activeTab = 'extract'">Extract</button>
-    </div>
-
-    <div v-if="activeTab === 'theory'" class="panel theory-content">
+  <CipherCard
+    title="Bacon's Cipher"
+    :encrypt-algorithm="() => baconEncrypt"
+    :decrypt-algorithm="() => baconDecrypt"
+    v-model:cipher-key="baconCipherKey"
+  >
+    <template #theory>
+      <h3>The Origin Story</h3>
       <p>
-        <strong>Bacon's Cipher</strong> is a steganographic technique from the early 1600s, credited to Francis Bacon.
-        Instead of scrambling letters like Caesar or Vigenère, it hides a message in plain sight by changing style.
+        <strong>Bacon's Cipher</strong> is a steganographic system attributed to Francis Bacon in the
+        early 1600s. Instead of disguising a message by shifting or scrambling letters, it hides the
+        payload inside an innocent-looking cover text by giving letters one of two visual styles.
       </p>
       <p>
-        The modern variant used here maps each secret letter A-Z to a five-character pattern made of <code>a</code> and
-        <code>b</code>. You can think of <code>a</code> as binary 0 and <code>b</code> as binary 1. Since five bits can represent
-        32 values, we have enough room to encode all 26 letters.
+        That distinction matters: this is less about secret math and more about covert signaling.
+        To a casual reader the text still looks readable, but to someone who knows the pattern, the
+        typography itself becomes the channel.
+      </p>
+
+      <h3>The Mechanics</h3>
+      <p>
+        The modern version used here maps each plaintext letter A-Z to a five-symbol pattern of
+        <code>a</code> and <code>b</code>. Think of <code>a</code> as binary <code>0</code> and
+        <code>b</code> as binary <code>1</code>. Because five bits can represent 32 values, that is
+        enough room to cover the 26-letter alphabet.
       </p>
       <p>
-        In Cryptotron, each alphabetic character in the cover text carries one bit:
+        Cryptotron applies those bits to the <em>alphabetic</em> characters in the cover text from
+        left to right:
       </p>
       <ul>
-        <li><strong>Type A</strong> (normal weight) = <code>a</code> = 0</li>
-        <li><strong>Type B</strong> (bright emphasized text) = <code>b</code> = 1</li>
+        <li><strong>Type A</strong> = normal weight = <code>a</code> = 0</li>
+        <li><strong>Type B</strong> = emphasized neon weight = <code>b</code> = 1</li>
       </ul>
       <p>
-        After five styled letters, the decoder reads one hidden character. Spaces and punctuation are preserved in the
-        cover text but do not consume bits.
+        Spaces, punctuation, and other non-letter characters stay visible in the cover text, but
+        they do not consume bits. That means only letters count toward the available hiding
+        capacity.
       </p>
+
+      <h3>The Binary Mapping</h3>
       <p>
-        <strong>Example:</strong> The letter <code>H</code> is index 7 in A=0 indexing, binary <code>00111</code>, which becomes
-        <code>aabbb</code>. If your cover starts with "There...", the first five alphabetic letters would be styled as:
-        normal, normal, bold, bold, bold.
+        Internally, the encoder converts each secret letter to its alphabet index using A=0,
+        B=1, ..., Z=25. That number is then written as a five-bit binary value and translated into
+        <code>a</code>/<code>b</code> symbols.
       </p>
-      <p>
-        To hide a full message, the app concatenates these five-bit groups and applies them left-to-right over the
-        cover text. To extract, it reads styling back into bits, chunks them by five, and maps each chunk to a letter.
-      </p>
-      <p>
-        Use this when you want subtle message hiding rather than cryptographic strength. Anyone who notices the
-        style pattern can decode it, so the real security comes from plausible cover text and not drawing attention to
-        the Type A/Type B distinction.
-      </p>
-    </div>
-
-    <div v-if="activeTab === 'hide'" class="panel">
-      <label>Secret Message</label>
-      <textarea v-model="secretMessage" rows="4" />
-
-      <label>Cover Text</label>
-      <textarea v-model="coverText" rows="6" />
-
-      <p v-if="lengthError" class="error">{{ lengthError }}</p>
-
-      <div class="preview" :class="{ reveal: revealMode }">
-        <span v-for="(item, idx) in preview" :key="idx" :class="`b-${item.type}`">{{ item.char }}</span>
+      <div class="cipher-example">
+        <strong>Worked example:</strong><br />
+        H = 7<br />
+        7 in binary = <code>00111</code><br />
+        <code>00111</code> becomes <code>aabbb</code><br />
+        So the next five alphabetic letters in the cover text are styled as:
+        normal, normal, emphasized, emphasized, emphasized.
       </div>
+      <p>
+        If your secret message is <code>HELLO</code>, the encoder creates 25 total bits, so you need
+        at least 25 alphabetic characters in the cover text. That acceptance rule is enforced here
+        to prevent partial or ambiguous output.
+      </p>
 
-      <label>HTML Export</label>
-      <textarea :value="htmlExport" rows="6" readonly />
+      <h3>Encoding and Extraction</h3>
+      <p>
+        In the <strong>Hide</strong> workflow, the app cleans the secret message down to A-Z,
+        converts every letter into five Bacon bits, then overlays those bits onto the cover text.
+        The live preview shows what the styled carrier text will look like.
+      </p>
+      <p>
+        In the <strong>Extract</strong> workflow, the decoder reads the style markers back in. Bold
+        or <code>b-b</code> spans are treated as binary 1, unstyled or Type A letters become binary
+        0, and the stream is then chunked into five-bit groups to recover the hidden message.
+      </p>
+      <p>
+        The HTML export preserves explicit <code>span</code> classes for reliable recovery, while the
+        Markdown export uses bold formatting as a lightweight fallback.
+      </p>
 
-      <label>Markdown Export</label>
-      <textarea :value="markdownExport" rows="4" readonly />
-    </div>
+      <h3>Modern Perspective</h3>
+      <p>
+        Bacon's Cipher is a good lesson in the difference between <strong>encryption</strong> and
+        <strong>steganography</strong>. The message is not mathematically protected against a curious
+        observer who notices the pattern; instead, the goal is to avoid attracting attention in the
+        first place.
+      </p>
+      <p>
+        So the real risk is not brute force. It is detection. If the styling contrast is too loud,
+        the carrier text looks suspicious. If the cover text is too short or unnatural, the pattern
+        becomes easier to spot. What matters is not just whether the encoding works, but whether the
+        hiding still looks plausible.
+      </p>
+    </template>
 
-    <div v-if="activeTab === 'extract'" class="panel">
-      <label>Encoded Text (HTML/Markdown)</label>
-      <textarea v-model="encodedInput" rows="8" />
+    <template #cipherKey>
+      <div class="bacon-practice-stack">
+        <div class="control-group">
+          <label class="control-label">Secret Message</label>
+          <textarea
+            v-model="secretMessage"
+            rows="4"
+            class="cipher-textarea"
+            placeholder="Enter the hidden message..."
+          />
+        </div>
 
-      <label>Extracted Secret</label>
-      <textarea :value="extracted" rows="3" readonly />
-    </div>
-  </section>
+        <div class="control-group">
+          <label class="control-label">Cover Text</label>
+          <textarea
+            v-model="coverText"
+            rows="6"
+            class="cipher-textarea"
+            placeholder="Enter the visible carrier text..."
+          />
+        </div>
+
+        <p v-if="lengthError" class="status-error bacon-inline-error">
+          <span>{{ lengthError }}</span>
+        </p>
+
+        <div class="control-group">
+          <div class="bacon-preview-header">
+            <label class="control-label">Live Preview</label>
+            <button class="cipher-button bacon-secondary-button" type="button" @click="revealMode = !revealMode">
+              {{ revealMode ? 'Hide Reveal' : 'Reveal Bits' }}
+            </button>
+          </div>
+          <div class="bacon-preview" :class="{ reveal: revealMode }">
+            <span v-for="(item, idx) in preview" :key="idx" :class="`b-${item.type}`">{{ item.char }}</span>
+          </div>
+        </div>
+
+        <div class="control-group">
+          <div class="bacon-preview-header">
+            <label class="control-label">Export Output</label>
+            <div class="bacon-export-actions">
+              <button
+                class="cipher-button bacon-secondary-button"
+                type="button"
+                @click="exportMode = exportMode === 'html' ? 'markdown' : 'html'"
+              >
+                {{ exportMode === 'html' ? 'Switch to Markdown' : 'Switch to HTML' }}
+              </button>
+              <button class="cipher-button bacon-secondary-button" type="button" @click="copyActiveExport">
+                Copy {{ exportMode.toUpperCase() }}
+              </button>
+            </div>
+          </div>
+          <p v-if="copiedNotice" class="bacon-copy-notice">{{ copiedNotice }}</p>
+          <textarea :value="activeExport" rows="8" class="cipher-textarea" readonly />
+        </div>
+
+        <div class="control-group">
+          <label class="control-label">Encoded Text (HTML/Markdown)</label>
+          <textarea
+            v-model="encodedInput"
+            rows="8"
+            class="cipher-textarea"
+            placeholder="Paste exported Bacon text here to decode..."
+          />
+        </div>
+
+        <div class="control-group">
+          <label class="control-label">Extracted Secret</label>
+          <textarea :value="extracted" rows="3" class="cipher-textarea" readonly />
+        </div>
+      </div>
+    </template>
+  </CipherCard>
 </template>
 
 <style scoped>
-.bacon-view { display: grid; gap: 1rem; }
-.tabs { display: flex; gap: 0.5rem; }
-button.active { border-color: var(--neon-green); color: var(--neon-green); }
-.panel {
+.bacon-practice-stack {
   display: grid;
+  gap: 1.25rem;
+}
+
+.bacon-preview-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+
+.bacon-export-actions {
+  display: flex;
   gap: 0.75rem;
-  border: 1px solid var(--cryptotron-grid-color);
-  border-radius: 10px;
-  background: var(--panel-bg);
+  flex-wrap: wrap;
+}
+
+.bacon-secondary-button {
+  padding: 0.6rem 1rem;
+}
+
+.bacon-preview {
+  border: 1px solid var(--cryptotron-border-glow);
+  background: rgba(0, 0, 0, 0.7);
+  border-radius: 8px;
   padding: 1rem;
+  min-height: 5rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--cryptotron-text-primary);
+  font-family: 'Space Mono', monospace;
 }
 
-.panel label {
-  font-weight: 600;
-  color: var(--text-secondary);
+.b-a {
+  font-weight: 400;
+  color: var(--cryptotron-text-primary);
 }
 
-.theory-content ul {
-  margin: 0;
-  padding-left: 1.25rem;
-  display: grid;
-  gap: 0.35rem;
+.b-b {
+  font-weight: 700;
+  color: var(--neon-green);
+  text-shadow: 0 0 5px var(--neon-green);
+}
+
+.bacon-preview.reveal .b-b {
+  color: var(--neon-magenta);
+  text-shadow: 0 0 8px var(--neon-magenta);
+}
+
+.bacon-inline-error {
+  margin-top: -0.25rem;
+}
+
+.bacon-copy-notice {
+  margin: 0 0 0.5rem;
+  color: var(--neon-green);
+  font-family: 'Space Mono', monospace;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
 }
 
 .theory-content code {
@@ -174,30 +310,10 @@ button.active { border-color: var(--neon-green); color: var(--neon-green); }
   color: var(--neon-green);
 }
 
-.preview {
-  border: 1px solid var(--cryptotron-grid-color);
-  background: color-mix(in srgb, var(--panel-bg) 85%, black 15%);
-  padding: 1rem;
-  border-radius: 8px;
-  min-height: 5rem;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-.b-a { font-weight: 400; color: var(--text-primary); }
-.b-b { font-weight: 700; color: var(--neon-green); text-shadow: 0 0 5px var(--neon-green); }
-.preview.reveal .b-b { color: var(--neon-magenta); text-shadow: 0 0 8px var(--neon-magenta); }
-.error { color: #ff6b6b; }
-textarea {
-  width: 100%;
-  border: 1px solid var(--cryptotron-grid-color);
-  border-radius: 8px;
-  background: var(--panel-bg);
-  color: var(--text-primary);
-  padding: 0.75rem;
-  resize: vertical;
-}
-
-textarea[readonly] {
-  opacity: 0.95;
+.theory-content ul {
+  margin: 0 0 1rem;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.35rem;
 }
 </style>

--- a/src/views/BaconView.vue
+++ b/src/views/BaconView.vue
@@ -4,12 +4,22 @@ import { computed, ref } from 'vue'
 import { baconDecoder, baconEncoder, toHtmlSnippet, toMarkdown, type StyledChar } from '@/utils/steganography'
 
 const baconCipherKey = ref({})
+const baconCoverKey = ref({ coverText: '' })
 const secretMessage = ref('')
-const coverText = ref('')
 const encodedInput = ref('')
 const revealMode = ref(false)
 const exportMode = ref<'html' | 'markdown'>('html')
 const copiedNotice = ref('')
+
+const coverText = computed({
+  get: () => baconCoverKey.value.coverText ?? '',
+  set: (value: string) => {
+    baconCoverKey.value = {
+      ...baconCoverKey.value,
+      coverText: value,
+    }
+  },
+})
 
 const preview = computed<StyledChar[]>(() => {
   try {
@@ -66,8 +76,15 @@ const copyActiveExport = async () => {
   }
 }
 
-const baconEncrypt = () => activeExport.value
-const baconDecrypt = () => extracted.value
+const baconEncrypt = (input: string) => {
+  secretMessage.value = input
+  return activeExport.value
+}
+
+const baconDecrypt = (input: string) => {
+  encodedInput.value = input
+  return extracted.value
+}
 </script>
 
 <template>
@@ -75,7 +92,7 @@ const baconDecrypt = () => extracted.value
     title="Bacon's Cipher"
     :encrypt-algorithm="() => baconEncrypt"
     :decrypt-algorithm="() => baconDecrypt"
-    v-model:cipher-key="baconCipherKey"
+    v-model:cipher-key="baconCoverKey"
   >
     <template #theory>
       <h3>The Origin Story</h3>
@@ -163,27 +180,19 @@ const baconDecrypt = () => extracted.value
     </template>
 
     <template #cipherKey>
+      <div class="control-group">
+        <label class="control-label">Cover Text</label>
+        <textarea
+          v-model="coverText"
+          rows="6"
+          class="cipher-textarea"
+          placeholder="Enter the visible carrier text..."
+        />
+      </div>
+    </template>
+
+    <template #encryptOutput>
       <div class="bacon-practice-stack">
-        <div class="control-group">
-          <label class="control-label">Secret Message</label>
-          <textarea
-            v-model="secretMessage"
-            rows="4"
-            class="cipher-textarea"
-            placeholder="Enter the hidden message..."
-          />
-        </div>
-
-        <div class="control-group">
-          <label class="control-label">Cover Text</label>
-          <textarea
-            v-model="coverText"
-            rows="6"
-            class="cipher-textarea"
-            placeholder="Enter the visible carrier text..."
-          />
-        </div>
-
         <p v-if="lengthError" class="status-error bacon-inline-error">
           <span>{{ lengthError }}</span>
         </p>
@@ -221,19 +230,16 @@ const baconDecrypt = () => extracted.value
         </div>
 
         <div class="control-group">
-          <label class="control-label">Encoded Text (HTML/Markdown)</label>
-          <textarea
-            v-model="encodedInput"
-            rows="8"
-            class="cipher-textarea"
-            placeholder="Paste exported Bacon text here to decode..."
-          />
-        </div>
-
-        <div class="control-group">
-          <label class="control-label">Extracted Secret</label>
+          <label class="control-label">Decoded Secret Preview</label>
           <textarea :value="extracted" rows="3" class="cipher-textarea" readonly />
         </div>
+      </div>
+    </template>
+
+    <template #decryptOutput>
+      <div class="control-group">
+        <label class="control-label">Decoded Secret Preview</label>
+        <textarea :value="extracted" rows="3" class="cipher-textarea" readonly />
       </div>
     </template>
   </CipherCard>

--- a/src/views/BaconView.vue
+++ b/src/views/BaconView.vue
@@ -1,0 +1,115 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { baconDecoder, baconEncoder, toHtmlSnippet, toMarkdown, type StyledChar } from '@/utils/steganography'
+
+const activeTab = ref<'theory' | 'hide' | 'extract'>('theory')
+const revealMode = ref(false)
+
+const secretMessage = ref('')
+const coverText = ref('')
+const encodedInput = ref('')
+
+const preview = computed<StyledChar[]>(() => {
+  try {
+    return baconEncoder(secretMessage.value, coverText.value)
+  } catch {
+    return [...coverText.value].map((char) => ({ char, type: 'a' as const }))
+  }
+})
+
+const bitLength = computed(() => secretMessage.value.toUpperCase().replace(/[^A-Z]/g, '').length * 5)
+const alphaLength = computed(() => [...coverText.value].filter((c) => /[A-Za-z]/.test(c)).length)
+const lengthError = computed(() =>
+  bitLength.value > 0 && alphaLength.value < bitLength.value
+    ? `Cover Text needs at least ${bitLength.value} alphabetic characters (has ${alphaLength.value}).`
+    : '',
+)
+
+const extracted = computed(() => baconDecoder(encodedInput.value))
+
+const htmlExport = computed(() => toHtmlSnippet(preview.value))
+const markdownExport = computed(() => toMarkdown(preview.value))
+
+const handleHotkey = (event: KeyboardEvent) => {
+  if (event.target instanceof HTMLTextAreaElement || event.target instanceof HTMLInputElement) return
+
+  if (event.key === 'r') revealMode.value = !revealMode.value
+  if (event.key === 'e') activeTab.value = 'hide'
+  if (event.key === 'd') activeTab.value = 'extract'
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('keydown', handleHotkey)
+}
+</script>
+
+<template>
+  <section class="bacon-view">
+    <h1>Bacon's Cipher</h1>
+
+    <div class="tabs">
+      <button :class="{ active: activeTab === 'theory' }" @click="activeTab = 'theory'">Theory</button>
+      <button :class="{ active: activeTab === 'hide' }" @click="activeTab = 'hide'">Hide</button>
+      <button :class="{ active: activeTab === 'extract' }" @click="activeTab = 'extract'">Extract</button>
+    </div>
+
+    <div v-if="activeTab === 'theory'" class="panel">
+      <p>
+        Bacon's Cipher maps each plaintext letter (A-Z) into a 5-symbol sequence of a/b, then hides those
+        symbols in visible typography changes across a cover text.
+      </p>
+      <p>
+        In this implementation, normal letters are Type A and emphasized letters are Type B. Five styled letters
+        decode to one secret character.
+      </p>
+    </div>
+
+    <div v-if="activeTab === 'hide'" class="panel">
+      <label>Secret Message</label>
+      <textarea v-model="secretMessage" rows="4" />
+
+      <label>Cover Text</label>
+      <textarea v-model="coverText" rows="6" />
+
+      <p v-if="lengthError" class="error">{{ lengthError }}</p>
+
+      <div class="preview" :class="{ reveal: revealMode }">
+        <span v-for="(item, idx) in preview" :key="idx" :class="`b-${item.type}`">{{ item.char }}</span>
+      </div>
+
+      <label>HTML Export</label>
+      <textarea :value="htmlExport" rows="6" readonly />
+
+      <label>Markdown Export</label>
+      <textarea :value="markdownExport" rows="4" readonly />
+    </div>
+
+    <div v-if="activeTab === 'extract'" class="panel">
+      <label>Encoded Text (HTML/Markdown)</label>
+      <textarea v-model="encodedInput" rows="8" />
+
+      <label>Extracted Secret</label>
+      <textarea :value="extracted" rows="3" readonly />
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.bacon-view { display: grid; gap: 1rem; }
+.tabs { display: flex; gap: 0.5rem; }
+button.active { border-color: var(--neon-green); color: var(--neon-green); }
+.panel { display: grid; gap: 0.6rem; }
+.preview {
+  border: 1px solid var(--cryptotron-grid-color);
+  padding: 1rem;
+  border-radius: 8px;
+  min-height: 5rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.b-a { font-weight: 400; color: var(--text-primary); }
+.b-b { font-weight: 700; color: var(--neon-green); text-shadow: 0 0 5px var(--neon-green); }
+.preview.reveal .b-b { color: var(--neon-magenta); text-shadow: 0 0 8px var(--neon-magenta); }
+.error { color: #ff6b6b; }
+textarea { width: 100%; }
+</style>

--- a/src/views/BaconView.vue
+++ b/src/views/BaconView.vue
@@ -96,7 +96,7 @@ const baconDecrypt = (input: string) => {
 
 <template>
   <CipherCard
-    title="Bacon's Cipher"
+    title="Bacon's Encoding"
     :encrypt-algorithm="() => baconEncrypt"
     :decrypt-algorithm="() => baconDecrypt"
     :encrypt-output-override="() => activeExport"
@@ -106,7 +106,7 @@ const baconDecrypt = (input: string) => {
     <template #theory>
       <h3>The Origin Story</h3>
       <p>
-        <strong>Bacon's Cipher</strong> is a steganographic system attributed to Francis Bacon in the
+        <strong>Bacon's Encoding</strong> is a steganographic system attributed to Francis Bacon in the
         early 1600s. Instead of disguising a message by shifting or scrambling letters, it hides the
         payload inside an innocent-looking cover text by giving letters one of two visual styles.
       </p>
@@ -175,7 +175,7 @@ const baconDecrypt = (input: string) => {
 
       <h3>Modern Perspective</h3>
       <p>
-        Bacon's Cipher is a good lesson in the difference between <strong>encryption</strong> and
+        Bacon's Encoding is a good lesson in the difference between <strong>encryption</strong> and
         <strong>steganography</strong>. The message is not mathematically protected against a curious
         observer who notices the pattern; instead, the goal is to avoid attracting attention in the
         first place.

--- a/src/views/BaconView.vue
+++ b/src/views/BaconView.vue
@@ -238,6 +238,8 @@ const baconDecrypt = (input: string) => {
 </template>
 
 <style scoped>
+@import '@/assets/cipher-card.css';
+
 .bacon-practice-stack {
   display: grid;
   gap: 1.25rem;
@@ -258,33 +260,6 @@ const baconDecrypt = (input: string) => {
   flex-wrap: wrap;
 }
 
-.bacon-export-actions .cipher-button {
-  background: linear-gradient(45deg, rgba(0, 255, 255, 0.2), rgba(255, 0, 255, 0.2));
-  border: 1px solid var(--neon-cyan);
-  border-radius: 6px;
-  padding: 0.75rem 1.5rem;
-  color: var(--cryptotron-text-primary);
-  font-family: 'Orbitron', monospace;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  cursor: pointer;
-  transition: all 0.3s ease;
-}
-
-.bacon-export-actions .cipher-button:hover {
-  box-shadow: 0 0 20px rgba(0, 255, 255, 0.5);
-  transform: translateY(-2px);
-}
-
-.bacon-export-actions .cipher-button:active {
-  transform: translateY(0);
-}
-
-.bacon-export-actions .cipher-button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
 
 .bacon-preview {
   border: 1px solid var(--cryptotron-border-glow);

--- a/src/views/BaconView.vue
+++ b/src/views/BaconView.vue
@@ -7,7 +7,7 @@ const baconCipherKey = ref({})
 const baconCoverKey = ref({ coverText: '' })
 const secretMessage = ref('')
 const encodedInput = ref('')
-const revealMode = ref(false)
+const highlightHiddenBits = ref(false)
 const exportMode = ref<'html' | 'markdown'>('html')
 const copiedNotice = ref('')
 
@@ -200,11 +200,11 @@ const baconDecrypt = (input: string) => {
         <div class="control-group">
           <div class="bacon-preview-header">
             <label class="control-label">Live Preview</label>
-            <button class="cipher-button bacon-secondary-button" type="button" @click="revealMode = !revealMode">
-              {{ revealMode ? 'Hide Reveal' : 'Reveal Bits' }}
+            <button class="cipher-button" type="button" @click="highlightHiddenBits = !highlightHiddenBits">
+              {{ highlightHiddenBits ? 'Normal Preview' : 'Highlight Hidden Bits' }}
             </button>
           </div>
-          <div class="bacon-preview" :class="{ reveal: revealMode }">
+          <div class="bacon-preview" :class="{ reveal: highlightHiddenBits }">
             <span v-for="(item, idx) in preview" :key="idx" :class="`b-${item.type}`">{{ item.char }}</span>
           </div>
         </div>
@@ -229,10 +229,6 @@ const baconDecrypt = (input: string) => {
           <textarea :value="activeExport" rows="8" class="cipher-textarea" readonly />
         </div>
 
-        <div class="control-group">
-          <label class="control-label">Decoded Secret Preview</label>
-          <textarea :value="extracted" rows="3" class="cipher-textarea" readonly />
-        </div>
       </div>
     </template>
 
@@ -264,10 +260,6 @@ const baconDecrypt = (input: string) => {
   display: flex;
   gap: 0.75rem;
   flex-wrap: wrap;
-}
-
-.bacon-secondary-button {
-  padding: 0.6rem 1rem;
 }
 
 .bacon-preview {

--- a/src/views/BaconView.vue
+++ b/src/views/BaconView.vue
@@ -3,7 +3,6 @@ import CipherCard from '@/components/CipherCard.vue'
 import { computed, ref } from 'vue'
 import { baconDecoder, baconEncoder, toHtmlSnippet, toMarkdown, type StyledChar } from '@/utils/steganography'
 
-const baconCipherKey = ref({})
 const baconCoverKey = ref({ coverText: '' })
 const secretMessage = ref('')
 const encodedInput = ref('')

--- a/src/views/BaconView.vue
+++ b/src/views/BaconView.vue
@@ -83,11 +83,19 @@ const handleBaconNormalModeKey = (key: string, activeTab: string) => {
   return true
 }
 
+/**
+ * Adapter used by CipherCard: mutates reactive state, then returns a computed value.
+ * This relies on Vue's synchronous ref updates; use pure encoder/decoder helpers for non-mutating transforms.
+ */
 const baconEncrypt = (input: string) => {
   secretMessage.value = input
   return activeExport.value
 }
 
+/**
+ * Adapter used by CipherCard: mutates reactive state, then returns a computed value.
+ * This relies on Vue's synchronous ref updates; use pure encoder/decoder helpers for non-mutating transforms.
+ */
 const baconDecrypt = (input: string) => {
   encodedInput.value = input
   return extracted.value

--- a/src/views/BaconView.vue
+++ b/src/views/BaconView.vue
@@ -91,6 +91,7 @@ const baconDecrypt = (input: string) => {
     title="Bacon's Cipher"
     :encrypt-algorithm="() => baconEncrypt"
     :decrypt-algorithm="() => baconDecrypt"
+    :encrypt-output-override="() => activeExport"
     v-model:cipher-key="baconCoverKey"
   >
     <template #theory>

--- a/src/views/BaconView.vue
+++ b/src/views/BaconView.vue
@@ -75,6 +75,14 @@ const copyActiveExport = async () => {
   }
 }
 
+const handleBaconNormalModeKey = (key: string, activeTab: string) => {
+  if (activeTab !== 'encrypt') return false
+  if (key !== 'm') return false
+
+  exportMode.value = exportMode.value === 'html' ? 'markdown' : 'html'
+  return true
+}
+
 const baconEncrypt = (input: string) => {
   secretMessage.value = input
   return activeExport.value
@@ -92,6 +100,7 @@ const baconDecrypt = (input: string) => {
     :encrypt-algorithm="() => baconEncrypt"
     :decrypt-algorithm="() => baconDecrypt"
     :encrypt-output-override="() => activeExport"
+    :normal-mode-key-handler="handleBaconNormalModeKey"
     v-model:cipher-key="baconCoverKey"
   >
     <template #theory>
@@ -215,7 +224,7 @@ const baconDecrypt = (input: string) => {
                 type="button"
                 @click="exportMode = exportMode === 'html' ? 'markdown' : 'html'"
               >
-                {{ exportMode === 'html' ? 'Switch to Markdown' : 'Switch to HTML' }}
+                {{ exportMode === 'html' ? 'Switch to Markdown (m)' : 'Switch to HTML (m)' }}
               </button>
               <button class="cipher-button bacon-secondary-button" type="button" @click="copyActiveExport">
                 Copy {{ exportMode.toUpperCase() }}

--- a/src/views/BaconView.vue
+++ b/src/views/BaconView.vue
@@ -7,7 +7,6 @@ const baconCipherKey = ref({})
 const baconCoverKey = ref({ coverText: '' })
 const secretMessage = ref('')
 const encodedInput = ref('')
-const highlightHiddenBits = ref(false)
 const exportMode = ref<'html' | 'markdown'>('html')
 const copiedNotice = ref('')
 
@@ -200,11 +199,8 @@ const baconDecrypt = (input: string) => {
         <div class="control-group">
           <div class="bacon-preview-header">
             <label class="control-label">Live Preview</label>
-            <button class="cipher-button" type="button" @click="highlightHiddenBits = !highlightHiddenBits">
-              {{ highlightHiddenBits ? 'Normal Preview' : 'Highlight Hidden Bits' }}
-            </button>
           </div>
-          <div class="bacon-preview" :class="{ reveal: highlightHiddenBits }">
+          <div class="bacon-preview">
             <span v-for="(item, idx) in preview" :key="idx" :class="`b-${item.type}`">{{ item.char }}</span>
           </div>
         </div>
@@ -283,11 +279,6 @@ const baconDecrypt = (input: string) => {
   font-weight: 700;
   color: var(--neon-green);
   text-shadow: 0 0 5px var(--neon-green);
-}
-
-.bacon-preview.reveal .b-b {
-  color: var(--neon-magenta);
-  text-shadow: 0 0 8px var(--neon-magenta);
 }
 
 .bacon-inline-error {

--- a/src/views/BaconView.vue
+++ b/src/views/BaconView.vue
@@ -258,6 +258,34 @@ const baconDecrypt = (input: string) => {
   flex-wrap: wrap;
 }
 
+.bacon-export-actions .cipher-button {
+  background: linear-gradient(45deg, rgba(0, 255, 255, 0.2), rgba(255, 0, 255, 0.2));
+  border: 1px solid var(--neon-cyan);
+  border-radius: 6px;
+  padding: 0.75rem 1.5rem;
+  color: var(--cryptotron-text-primary);
+  font-family: 'Orbitron', monospace;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.bacon-export-actions .cipher-button:hover {
+  box-shadow: 0 0 20px rgba(0, 255, 255, 0.5);
+  transform: translateY(-2px);
+}
+
+.bacon-export-actions .cipher-button:active {
+  transform: translateY(0);
+}
+
+.bacon-export-actions .cipher-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .bacon-preview {
   border: 1px solid var(--cryptotron-border-glow);
   background: rgba(0, 0, 0, 0.7);

--- a/src/views/BaconView.vue
+++ b/src/views/BaconView.vue
@@ -26,8 +26,8 @@ const preview = computed<StyledChar[]>(() => {
   } catch (error) {
     console.error('Bacon encoder preview failed', {
       error,
-      secretMessage: secretMessage.value,
-      coverText: coverText.value,
+      secretLength: secretMessage.value.length,
+      coverLength: coverText.value.length,
     })
     return [...coverText.value].map((char) => ({ char, type: 'a' as const }))
   }
@@ -47,7 +47,7 @@ const extracted = computed(() => {
   } catch (error) {
     console.error('Bacon decoder extraction failed', {
       error,
-      encodedInput: encodedInput.value,
+      inputLength: encodedInput.value.length,
     })
     return ''
   }

--- a/src/views/BaconView.vue
+++ b/src/views/BaconView.vue
@@ -29,7 +29,7 @@ const preview = computed<StyledChar[]>(() => {
       secretLength: secretMessage.value.length,
       coverLength: coverText.value.length,
     })
-    return [...coverText.value].map((char) => ({ char, type: 'a' as const }))
+    return [...coverText.value].map((char) => ({ char, type: 'a' as const, carriesBit: false }))
   }
 })
 


### PR DESCRIPTION
## Summary
- add Bacon steganography encoder/decoder utilities
- add Bacon view with Theory/Hide/Extract workflows, export (HTML/Markdown), and extraction
- align terminology to steganography language ("Bacon's Encoding", "Steganography")
- add keyboard UX polish for Bacon + CipherCard (`m` export toggle, `i`/`k` focus behavior, yank output override)
- tighten `CipherCard` prop typings and document Bacon adapter side-effects
- register route and navigation entry for the Bacon module

Closes #13

## Verification
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bacon’s Encoding cipher: live encode/decode UI with styled preview, HTML/Markdown export, copy-to-clipboard, cover-text capacity validation, decoded preview, and theory/info section.
* **Improvements**
  * Added steganography utilities for Bacon-style encoding/decoding and HTML/Markdown output.
  * Navigation entry for the new cipher.
  * Cipher card: customizable output slots, improved input focus, and extended keyboard/shortcut handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jabez007/cryptotron.vue/pull/18)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->