### PR TITLE
Hide redundant cover text in decrypt tab

### DIFF
--- a/src/components/CipherCard.vue
+++ b/src/components/CipherCard.vue
@@ -61,7 +61,7 @@
           <div class="cipher-practice">
             <h2 class="section-title">Encrypt Messages</h2>
             <div class="control-group">
-              <slot name="cipherKey"></slot>
+              <slot name="cipherKey" panel="encrypt"></slot>
             </div>
 
             <div class="control-group">
@@ -98,7 +98,7 @@
           <div class="cipher-practice">
             <h2 class="section-title">Decrypt Messages</h2>
             <div class="control-group">
-              <slot name="cipherKey"></slot>
+              <slot name="cipherKey" panel="decrypt"></slot>
             </div>
 
             <div class="control-group">

--- a/src/views/BaconView.vue
+++ b/src/views/BaconView.vue
@@ -195,8 +195,8 @@ const baconDecrypt = (input: string) => {
       </p>
     </template>
 
-    <template #cipherKey>
-      <div class="control-group">
+    <template #cipherKey="{ panel }">
+      <div v-if="panel !== 'decrypt'" class="control-group">
         <label class="control-label">Cover Text</label>
         <textarea
           v-model="coverText"


### PR DESCRIPTION
Enhance CipherCard to pass the panel identifier to the cipherKey slot. Use this in BaconView to hide the "Cover Text" field during decryption, as it is unnecessary for extraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * The Cover Text input field now appears only during encryption operations, removing it from the decryption panel for a cleaner interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jabez007/cryptotron.vue/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->