### PR TITLE
Add steganography rules to builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jabez007/cryptotron.vue",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jabez007/cryptotron.vue",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "@jabez007/cryptotron.js": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jabez007/cryptotron.vue",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/src/__tests__/builder_utils.test.ts
+++ b/src/__tests__/builder_utils.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { isSteganographyType, validateSteganographyTopology } from '@/components/builder/utils'
+
+describe('builder steganography topology', () => {
+  it('recognizes steganography node types', () => {
+    expect(isSteganographyType('bacon')).toBe(true)
+    expect(isSteganographyType('emoji-smuggling')).toBe(true)
+    expect(isSteganographyType('acrostic')).toBe(true)
+    expect(isSteganographyType('caesar')).toBe(false)
+  })
+
+  it('allows graphs with no steganography nodes', () => {
+    const error = validateSteganographyTopology(
+      [
+        { id: '1', data: { type: 'caesar' } },
+        { id: '2', data: { type: 'vigenere' } },
+      ],
+      [{ source: '1', target: '2' }],
+    )
+
+    expect(error).toBeNull()
+  })
+
+  it('rejects graphs with multiple steganography nodes', () => {
+    const error = validateSteganographyTopology(
+      [
+        { id: '1', data: { type: 'bacon' } },
+        { id: '2', data: { type: 'emoji-smuggling' } },
+      ],
+      [],
+    )
+
+    expect(error).toMatch(/Only one steganography node/)
+  })
+
+  it('rejects graphs where steganography is not terminal', () => {
+    const error = validateSteganographyTopology(
+      [
+        { id: '1', data: { type: 'caesar' } },
+        { id: '2', data: { type: 'bacon' } },
+        { id: '3', data: { type: 'vigenere' } },
+      ],
+      [
+        { source: '1', target: '2' },
+        { source: '2', target: '3' },
+      ],
+    )
+
+    expect(error).toMatch(/last step in encryption/)
+  })
+
+  it('rejects graphs with multiple inputs into a steganography node', () => {
+    const error = validateSteganographyTopology(
+      [
+        { id: '1', data: { type: 'caesar' } },
+        { id: '2', data: { type: 'vigenere' } },
+        { id: '3', data: { type: 'emoji-smuggling' } },
+      ],
+      [
+        { source: '1', target: '3' },
+        { source: '2', target: '3' },
+      ],
+    )
+
+    expect(error).toMatch(/only accept one input path/)
+  })
+
+  it('allows a classical chain that ends in a steganography node', () => {
+    const error = validateSteganographyTopology(
+      [
+        { id: '1', data: { type: 'caesar' } },
+        { id: '2', data: { type: 'vigenere' } },
+        { id: '3', data: { type: 'acrostic' } },
+      ],
+      [
+        { source: '1', target: '2' },
+        { source: '2', target: '3' },
+      ],
+    )
+
+    expect(error).toBeNull()
+  })
+})

--- a/src/__tests__/constants.test.ts
+++ b/src/__tests__/constants.test.ts
@@ -128,6 +128,14 @@ describe('availableCiphers – structural integrity', () => {
 })
 
 describe('builder steganography wrappers', () => {
+  it('bacon builder wrapper returns empty string for empty input', () => {
+    const bacon = availableCiphers.find((cipher) => cipher.type === 'bacon')
+    expect(bacon).toBeDefined()
+
+    const encrypt = bacon!.encryptAlgorithm({ coverText: 'abcdefghij', exportMode: 'html' })
+    expect(encrypt('')).toBe('')
+  })
+
   it('bacon builder wrapper rejects lossy input before baconEncoder', () => {
     const bacon = availableCiphers.find((cipher) => cipher.type === 'bacon')
     expect(bacon).toBeDefined()

--- a/src/__tests__/constants.test.ts
+++ b/src/__tests__/constants.test.ts
@@ -126,3 +126,23 @@ describe('availableCiphers – structural integrity', () => {
     expect(unique.size).toBe(types.length)
   })
 })
+
+describe('builder steganography wrappers', () => {
+  it('bacon builder wrapper rejects lossy input before baconEncoder', () => {
+    const bacon = availableCiphers.find((cipher) => cipher.type === 'bacon')
+    expect(bacon).toBeDefined()
+
+    const encrypt = bacon!.encryptAlgorithm({ coverText: 'abcdefghij', exportMode: 'html' })
+    expect(() => encrypt('abc123')).toThrow(/baconEncrypt/)
+    expect(() => encrypt('abc123')).toThrow(/baconEncoder/)
+  })
+
+  it('acrostic builder wrapper rejects lossy input before generateAcrostic', () => {
+    const acrostic = availableCiphers.find((cipher) => cipher.type === 'acrostic')
+    expect(acrostic).toBeDefined()
+
+    const encrypt = acrostic!.encryptAlgorithm({ mode: 'acrostic' })
+    expect(() => encrypt('hello world')).toThrow(/acrosticEncrypt/)
+    expect(() => encrypt('hello world')).toThrow(/generateAcrostic/)
+  })
+})

--- a/src/components/builder/constants.ts
+++ b/src/components/builder/constants.ts
@@ -41,6 +41,7 @@ const validateStegoPlaintext = (
 
 const baconEncrypt =
   (key: { coverText?: string; exportMode?: 'html' | 'markdown' }) => (input: string) => {
+    if (input === '') return ''
     validateStegoPlaintext(input, 'baconEncrypt', 'baconEncoder')
     const preview = baconEncoder(input, key.coverText ?? '')
     return (key.exportMode ?? 'html') === 'html' ? toHtmlSnippet(preview) : toMarkdown(preview)

--- a/src/components/builder/constants.ts
+++ b/src/components/builder/constants.ts
@@ -11,11 +11,85 @@ import {
   substitution,
   vigenere,
 } from '@jabez007/cryptotron.js'
+import { generateAcrostic } from '@/utils/text-gen'
+import {
+  baconDecoder,
+  baconEncoder,
+  tagsDecoder,
+  tagsEncoder,
+  toHtmlSnippet,
+  toMarkdown,
+  type InvisibleEncodingMode,
+} from '@/utils/steganography'
+import type { AcrosticMode } from '@/components/keys/KeyAcrostic.vue'
+
+type CipherCategory = 'classical' | 'steganography'
+type CipherPlacement = 'any' | 'terminal'
+
+const baconEncrypt =
+  (key: { coverText?: string; exportMode?: 'html' | 'markdown' }) => (input: string) => {
+    const preview = baconEncoder(input, key.coverText ?? '')
+    return (key.exportMode ?? 'html') === 'html' ? toHtmlSnippet(preview) : toMarkdown(preview)
+  }
+
+const baconDecrypt = () => (input: string) => baconDecoder(input)
+const unsupportedCrack = () => {
+  throw new Error('Crack is not supported for this steganography technique.')
+}
+
+const emojiSmugglingEncrypt =
+  (key: {
+    coverText?: string
+    encodingMode?: InvisibleEncodingMode
+    interleave?: boolean
+  }) =>
+  (input: string) =>
+    tagsEncoder(
+      input,
+      key.coverText ?? '👍',
+      key.encodingMode ?? 'variation-selectors',
+      key.interleave ?? false,
+    )
+
+const emojiSmugglingDecrypt = () => (input: string) => tagsDecoder(input)
+
+const acrosticEncrypt = (key: { mode?: AcrosticMode }) => (input: string) =>
+  input ? generateAcrostic(input, key.mode ?? 'acrostic') : ''
+
+const stripAcrosticMetadata = (line: string) => line.trim().replace(/^(\[[^\]]+\]\s*)+/, '')
+
+const acrosticDecrypt = (key: { mode?: AcrosticMode }) => (input: string) => {
+  const lines = input.split('\n').filter((line) => line.trim().length > 0)
+  const mode = key.mode ?? 'acrostic'
+
+  if (mode === 'acrostic') {
+    return lines.map((line) => stripAcrosticMetadata(line)[0] || '').join('')
+  }
+
+  if (mode === 'telestic') {
+    return lines
+      .map((line) => {
+        const content = stripAcrosticMetadata(line)
+        return content[content.length - 1] || ''
+      })
+      .join('')
+  }
+
+  return lines
+    .map((line) => {
+      const content = stripAcrosticMetadata(line)
+      if (content.length < 2) return content
+      return content[0] + content[content.length - 1]
+    })
+    .join('')
+}
 
 export const availableCiphers = [
   {
     type: 'affine',
     label: 'Affine Cipher',
+    category: 'classical' as CipherCategory,
+    placement: 'any' as CipherPlacement,
     defaultKey: { alpha: 3, beta: 1 },
     encryptAlgorithm: affine.encrypt,
     decryptAlgorithm: affine.decrypt,
@@ -25,6 +99,8 @@ export const availableCiphers = [
   {
     type: 'autokey',
     label: 'Autokey Cipher',
+    category: 'classical' as CipherCategory,
+    placement: 'any' as CipherPlacement,
     defaultKey: { primer: 'bytewalker' },
     encryptAlgorithm: autokey.encrypt,
     decryptAlgorithm: autokey.decrypt,
@@ -34,6 +110,8 @@ export const availableCiphers = [
   {
     type: 'beaufort',
     label: 'Beaufort Cipher',
+    category: 'classical' as CipherCategory,
+    placement: 'any' as CipherPlacement,
     defaultKey: { keyword: 'nightcity' },
     encryptAlgorithm: beaufort.encrypt,
     decryptAlgorithm: beaufort.decrypt,
@@ -43,6 +121,8 @@ export const availableCiphers = [
   {
     type: 'caesar',
     label: 'Caesar Cipher',
+    category: 'classical' as CipherCategory,
+    placement: 'any' as CipherPlacement,
     defaultKey: { shift: 13 },
     encryptAlgorithm: caesar.encrypt,
     decryptAlgorithm: caesar.decrypt,
@@ -52,6 +132,8 @@ export const availableCiphers = [
   {
     type: 'columnar',
     label: 'Columnar Cipher',
+    category: 'classical' as CipherCategory,
+    placement: 'any' as CipherPlacement,
     defaultKey: { keyword: 'NIGHTCITY' },
     encryptAlgorithm: columnar.encrypt,
     decryptAlgorithm: columnar.decrypt,
@@ -61,6 +143,8 @@ export const availableCiphers = [
   {
     type: 'playfair',
     label: 'Playfair Cipher',
+    category: 'classical' as CipherCategory,
+    placement: 'any' as CipherPlacement,
     defaultKey: { keyword: 'MONARCHY' },
     encryptAlgorithm: playfair.encrypt,
     decryptAlgorithm: playfair.decrypt,
@@ -70,6 +154,8 @@ export const availableCiphers = [
   {
     type: 'polybius',
     label: 'Polybius Square',
+    category: 'classical' as CipherCategory,
+    placement: 'any' as CipherPlacement,
     defaultKey: { keyword: '', cipherChars: 'ABCDE' },
     encryptAlgorithm: polybius.encrypt,
     decryptAlgorithm: polybius.decrypt,
@@ -79,6 +165,8 @@ export const availableCiphers = [
   {
     type: 'rail-fence',
     label: 'Rail-Fence Cipher',
+    category: 'classical' as CipherCategory,
+    placement: 'any' as CipherPlacement,
     defaultKey: { rails: 3 },
     encryptAlgorithm: railFence.encrypt,
     decryptAlgorithm: railFence.decrypt,
@@ -88,6 +176,8 @@ export const availableCiphers = [
   {
     type: 'substitution',
     label: 'Substitution Cipher',
+    category: 'classical' as CipherCategory,
+    placement: 'any' as CipherPlacement,
     defaultKey: { cipherAlphabet: 'qwertyuiopasdfghjklzxcvbnm' },
     encryptAlgorithm: substitution.encrypt,
     decryptAlgorithm: substitution.decrypt,
@@ -97,13 +187,51 @@ export const availableCiphers = [
   {
     type: 'vigenere',
     label: 'Vigenère Cipher',
+    category: 'classical' as CipherCategory,
+    placement: 'any' as CipherPlacement,
     defaultKey: { keyword: 'mockraven' },
     encryptAlgorithm: vigenere.encrypt,
     decryptAlgorithm: vigenere.decrypt,
     crackAlgorithm: vigenere.crack,
     cipherKeyComponent: () => import('@/components/keys/KeyVigenere.vue'),
   },
-  // Add more cipher types as needed
+  {
+    type: 'bacon',
+    label: "Bacon's Encoding",
+    category: 'steganography' as CipherCategory,
+    placement: 'terminal' as CipherPlacement,
+    defaultKey: { coverText: '', exportMode: 'html' as const },
+    encryptAlgorithm: baconEncrypt,
+    decryptAlgorithm: baconDecrypt,
+    crackAlgorithm: unsupportedCrack,
+    cipherKeyComponent: () => import('@/components/keys/KeyBacon.vue'),
+  },
+  {
+    type: 'emoji-smuggling',
+    label: 'Emoji Smuggling',
+    category: 'steganography' as CipherCategory,
+    placement: 'terminal' as CipherPlacement,
+    defaultKey: {
+      coverText: '👍',
+      encodingMode: 'variation-selectors' as const,
+      interleave: false,
+    },
+    encryptAlgorithm: emojiSmugglingEncrypt,
+    decryptAlgorithm: emojiSmugglingDecrypt,
+    crackAlgorithm: unsupportedCrack,
+    cipherKeyComponent: () => import('@/components/keys/KeyEmojiSmuggling.vue'),
+  },
+  {
+    type: 'acrostic',
+    label: 'Acrostics',
+    category: 'steganography' as CipherCategory,
+    placement: 'terminal' as CipherPlacement,
+    defaultKey: { coverText: '', mode: 'acrostic' as const },
+    encryptAlgorithm: acrosticEncrypt,
+    decryptAlgorithm: acrosticDecrypt,
+    crackAlgorithm: unsupportedCrack,
+    cipherKeyComponent: () => import('@/components/keys/KeyAcrostic.vue'),
+  },
 ]
 
 export const cipherLookup = new Map(
@@ -114,6 +242,8 @@ export const cipherLookup = new Map(
       decryptAlgorithm: cipher.decryptAlgorithm,
       crackAlgorithm: cipher.crackAlgorithm,
       cipherKeyComponent: cipher.cipherKeyComponent,
+      category: cipher.category,
+      placement: cipher.placement,
     },
   ]),
 )
@@ -147,6 +277,20 @@ export const defaultNodes = [
     },
     position: { x: 100, y: 100 },
   },
+  {
+    id: '3',
+    label: 'Acrostics',
+    data: {
+      label: 'Acrostics',
+      type: 'acrostic',
+      encryptAlgorithm: acrosticEncrypt,
+      decryptAlgorithm: acrosticDecrypt,
+      crackAlgorithm: unsupportedCrack,
+      cipherKey: { coverText: '', mode: 'acrostic' as const },
+      cipherKeyComponent: () => import('@/components/keys/KeyAcrostic.vue'),
+    },
+    position: { x: 250, y: 195 },
+  },
 ]
 
 export const defaultEdges = [
@@ -154,6 +298,14 @@ export const defaultEdges = [
     id: 'e1-2',
     source: '1',
     target: '2',
+    updatable: true,
+    animated: true,
+    markerEnd: MarkerType.Arrow,
+  },
+  {
+    id: 'e2-3',
+    source: '2',
+    target: '3',
     updatable: true,
     animated: true,
     markerEnd: MarkerType.Arrow,

--- a/src/components/builder/constants.ts
+++ b/src/components/builder/constants.ts
@@ -25,9 +25,23 @@ import type { AcrosticMode } from '@/components/keys/KeyAcrostic.vue'
 
 type CipherCategory = 'classical' | 'steganography'
 type CipherPlacement = 'any' | 'terminal'
+const STEGO_PLAINTEXT_PATTERN = /^[a-z]+$/
+
+const validateStegoPlaintext = (
+  input: string,
+  wrapperName: 'baconEncrypt' | 'acrosticEncrypt',
+  helperName: 'baconEncoder' | 'generateAcrostic',
+) => {
+  if (!STEGO_PLAINTEXT_PATTERN.test(input)) {
+    throw new Error(
+      `[${wrapperName}] Rejecting lossy input before ${helperName}: expected lowercase ASCII letters matching /^[a-z]+$/.`,
+    )
+  }
+}
 
 const baconEncrypt =
   (key: { coverText?: string; exportMode?: 'html' | 'markdown' }) => (input: string) => {
+    validateStegoPlaintext(input, 'baconEncrypt', 'baconEncoder')
     const preview = baconEncoder(input, key.coverText ?? '')
     return (key.exportMode ?? 'html') === 'html' ? toHtmlSnippet(preview) : toMarkdown(preview)
   }
@@ -53,8 +67,11 @@ const emojiSmugglingEncrypt =
 
 const emojiSmugglingDecrypt = () => (input: string) => tagsDecoder(input)
 
-const acrosticEncrypt = (key: { mode?: AcrosticMode }) => (input: string) =>
-  input ? generateAcrostic(input, key.mode ?? 'acrostic') : ''
+const acrosticEncrypt = (key: { mode?: AcrosticMode }) => (input: string) => {
+  if (!input) return ''
+  validateStegoPlaintext(input, 'acrosticEncrypt', 'generateAcrostic')
+  return generateAcrostic(input, key.mode ?? 'acrostic')
+}
 
 const stripAcrosticMetadata = (line: string) => line.trim().replace(/^(\[[^\]]+\]\s*)+/, '')
 

--- a/src/components/builder/utils.ts
+++ b/src/components/builder/utils.ts
@@ -1,4 +1,39 @@
-import { type Connection, type Edge } from '@vue-flow/core'
+import { type Connection, type Edge, type Node } from '@vue-flow/core'
+
+const STEGANOGRAPHY_TYPES = new Set(['bacon', 'emoji-smuggling', 'acrostic'])
+
+export function isSteganographyType(type?: string): boolean {
+  return type ? STEGANOGRAPHY_TYPES.has(type) : false
+}
+
+export function validateSteganographyTopology(
+  nodes: Array<Pick<Node, 'id' | 'data'>>,
+  edges: Array<Pick<Edge, 'source' | 'target'>>,
+): string | null {
+  const stegoNodes = nodes.filter((node) => isSteganographyType(node.data?.type))
+
+  if (stegoNodes.length === 0) {
+    return null
+  }
+
+  if (stegoNodes.length > 1) {
+    return 'Only one steganography node can be used in a builder graph.'
+  }
+
+  const stegoNode = stegoNodes[0]
+  const outgoingCount = edges.filter((edge) => edge.source === stegoNode.id).length
+  const incomingCount = edges.filter((edge) => edge.target === stegoNode.id).length
+
+  if (outgoingCount > 0) {
+    return 'Steganography must be the last step in encryption and cannot feed into another node.'
+  }
+
+  if (incomingCount > 1) {
+    return 'Steganography nodes can only accept one input path.'
+  }
+
+  return null
+}
 
 /*
  * The Union-Find structure keeps track of connected components.

--- a/src/components/keys/KeyAcrostic.vue
+++ b/src/components/keys/KeyAcrostic.vue
@@ -1,0 +1,112 @@
+<template>
+  <div class="form-control">
+    <label class="control-label">
+      Position Mode:
+      <span class="label-hint">(m)</span>
+    </label>
+    <div class="mode-selector">
+      <button
+        v-for="option in modeOptions"
+        :key="option"
+        type="button"
+        class="mode-button"
+        :class="{ active: localMode === option }"
+        @click="localMode = option"
+      >
+        {{ labels[option] }}
+      </button>
+    </div>
+  </div>
+
+  <div class="form-control">
+    <label class="control-label">Cover Text:</label>
+    <textarea
+      v-model="localCoverText"
+      class="cipher-input"
+      rows="8"
+      placeholder="Generated or pasted carrier text will appear here..."
+    ></textarea>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+export type AcrosticMode = 'acrostic' | 'telestic' | 'compound'
+
+export interface AcrosticCipherKey {
+  coverText: string
+  mode: AcrosticMode
+}
+
+const modeOptions: AcrosticMode[] = ['acrostic', 'telestic', 'compound']
+const labels: Record<AcrosticMode, string> = {
+  acrostic: 'Acrostic',
+  telestic: 'Telestic',
+  compound: 'Compound',
+}
+
+interface Props {
+  cipherKey: AcrosticCipherKey
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  cipherKey: () => ({
+    coverText: '',
+    mode: 'acrostic',
+  }),
+})
+
+const emit = defineEmits<{
+  'update:cipherKey': [cipherKey: AcrosticCipherKey]
+}>()
+
+const localCoverText = computed({
+  get: () => props.cipherKey.coverText,
+  set: (coverText: string) => {
+    emit('update:cipherKey', {
+      ...props.cipherKey,
+      coverText,
+    })
+  },
+})
+
+const localMode = computed({
+  get: () => props.cipherKey.mode,
+  set: (mode: AcrosticMode) => {
+    emit('update:cipherKey', {
+      ...props.cipherKey,
+      mode,
+    })
+  },
+})
+</script>
+
+<style scoped>
+@import '@/assets/cipher-key.css';
+
+.mode-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.mode-button {
+  background: rgba(0, 255, 65, 0.08);
+  border: 1px solid rgba(0, 255, 65, 0.25);
+  border-radius: 999px;
+  color: inherit;
+  cursor: pointer;
+  padding: 0.5rem 0.9rem;
+}
+
+.mode-button.active {
+  background: var(--cryptotron-neon-cyan);
+  box-shadow: 0 0 10px var(--cryptotron-neon-cyan);
+  color: #000;
+}
+
+textarea.cipher-input {
+  resize: vertical;
+}
+</style>

--- a/src/components/keys/KeyAcrostic.vue
+++ b/src/components/keys/KeyAcrostic.vue
@@ -4,11 +4,13 @@
       Position Mode:
       <span class="label-hint">(m)</span>
     </label>
-    <div class="mode-selector">
+    <div class="mode-selector" role="radiogroup" aria-label="Acrostic position mode">
       <button
         v-for="option in modeOptions"
         :key="option"
         type="button"
+        role="radio"
+        :aria-checked="localMode === option"
         class="mode-button"
         :class="{ active: localMode === option }"
         @click="localMode = option"

--- a/src/components/keys/KeyBacon.vue
+++ b/src/components/keys/KeyBacon.vue
@@ -5,11 +5,13 @@
         Export Mode:
         <span class="label-hint">(m)</span>
       </label>
-      <div class="mode-selector">
+      <div class="mode-selector" role="radiogroup" aria-label="Bacon export mode">
         <button
           v-for="option in exportModeOptions"
           :key="option"
           type="button"
+          role="radio"
+          :aria-checked="localExportMode === option"
           class="mode-button"
           :class="{ active: localExportMode === option }"
           @click="localExportMode = option"

--- a/src/components/keys/KeyBacon.vue
+++ b/src/components/keys/KeyBacon.vue
@@ -1,0 +1,163 @@
+<template>
+  <div class="bacon-key-row">
+    <div class="form-control bacon-key-mode">
+      <label class="control-label">
+        Export Mode:
+        <span class="label-hint">(m)</span>
+      </label>
+      <div class="mode-selector">
+        <button
+          v-for="option in exportModeOptions"
+          :key="option"
+          type="button"
+          class="mode-button"
+          :class="{ active: localExportMode === option }"
+          @click="localExportMode = option"
+        >
+          {{ optionLabels[option] }}
+        </button>
+      </div>
+    </div>
+
+    <div class="form-control bacon-key-action">
+      <label class="control-label control-label-spacer" aria-hidden="true">Actions</label>
+      <button
+        class="cipher-button bacon-generate-button"
+        type="button"
+        @click="emit('generate-cover')"
+        :disabled="generateDisabled"
+      >
+        Generate Cover (g)
+      </button>
+    </div>
+  </div>
+
+  <div class="form-control">
+    <label class="control-label">Cover Text:</label>
+    <textarea
+      v-model="localCoverText"
+      class="cipher-input"
+      rows="6"
+      placeholder="Enter the visible carrier text..."
+    ></textarea>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+export interface BaconCipherKey {
+  coverText: string
+  exportMode: 'html' | 'markdown'
+}
+
+const exportModeOptions: BaconCipherKey['exportMode'][] = ['html', 'markdown']
+const optionLabels: Record<BaconCipherKey['exportMode'], string> = {
+  html: 'HTML',
+  markdown: 'Markdown',
+}
+
+interface Props {
+  cipherKey: BaconCipherKey
+  generateDisabled?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  cipherKey: () => ({
+    coverText: '',
+    exportMode: 'html',
+  }),
+  generateDisabled: false,
+})
+
+const emit = defineEmits<{
+  'update:cipherKey': [cipherKey: BaconCipherKey]
+  'generate-cover': []
+}>()
+
+const localCoverText = computed({
+  get: () => props.cipherKey.coverText,
+  set: (coverText: string) => {
+    emit('update:cipherKey', {
+      ...props.cipherKey,
+      coverText,
+    })
+  },
+})
+
+const localExportMode = computed({
+  get: () => props.cipherKey.exportMode,
+  set: (exportMode: 'html' | 'markdown') => {
+    emit('update:cipherKey', {
+      ...props.cipherKey,
+      exportMode,
+    })
+  },
+})
+</script>
+
+<style scoped>
+@import '@/assets/cipher-key.css';
+
+.bacon-key-row {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+}
+
+.bacon-key-mode {
+  min-width: 0;
+}
+
+.bacon-key-action {
+  align-self: end;
+}
+
+.mode-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.mode-button {
+  background: rgba(0, 255, 65, 0.08);
+  border: 1px solid rgba(0, 255, 65, 0.25);
+  border-radius: 999px;
+  color: inherit;
+  cursor: pointer;
+  padding: 0.5rem 0.9rem;
+}
+
+.mode-button.active {
+  background: var(--cryptotron-neon-cyan);
+  box-shadow: 0 0 10px var(--cryptotron-neon-cyan);
+  color: #000;
+}
+
+.control-label-spacer {
+  visibility: hidden;
+}
+
+.bacon-generate-button {
+  white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .bacon-key-row {
+    grid-template-columns: 1fr;
+  }
+
+  .control-label-spacer {
+    display: none;
+  }
+
+  .bacon-generate-button {
+    width: 100%;
+  }
+}
+
+textarea.cipher-input {
+  resize: vertical;
+}
+</style>

--- a/src/components/keys/KeyEmojiSmuggling.vue
+++ b/src/components/keys/KeyEmojiSmuggling.vue
@@ -1,0 +1,234 @@
+<template>
+  <div class="form-control">
+    <label class="control-label">
+      Encoding Mode:
+      <span class="label-hint">(m)</span>
+    </label>
+    <select v-model="localEncodingMode" class="cipher-input">
+      <option v-for="option in modeOptions" :key="option.value" :value="option.value">
+        {{ option.label }}
+      </option>
+    </select>
+    <div class="mode-help">
+      <div class="mode-help-header">
+        <span class="mode-help-title">{{ currentMode.title }}</span>
+        <span v-if="currentMode.recommended" class="mode-badge">Recommended</span>
+      </div>
+      <p class="mode-help-copy">{{ currentMode.description }}</p>
+    </div>
+  </div>
+
+  <div class="form-control">
+    <label class="control-label">Carrier Emoji / Cover Text:</label>
+    <div class="emoji-picker">
+      <button
+        v-for="emoji in emojiOptions"
+        :key="emoji"
+        type="button"
+        class="emoji-chip"
+        @click="localCoverText = emoji"
+      >
+        {{ emoji }}
+      </button>
+    </div>
+    <div class="emoji-picker">
+      <button
+        v-for="emoji in emojiOptions"
+        :key="`${emoji}-append`"
+        type="button"
+        class="emoji-chip secondary"
+        @click="localCoverText = `${localCoverText}${emoji}`"
+      >
+        +{{ emoji }}
+      </button>
+    </div>
+    <textarea
+      v-model="localCoverText"
+      class="cipher-input"
+      rows="3"
+      placeholder="Paste your own emoji or carrier text here..."
+    ></textarea>
+  </div>
+
+  <div class="form-control checkbox-control">
+    <label class="checkbox-label">
+      <input v-model="localInterleave" type="checkbox" />
+      Interleave Payload
+    </label>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { InvisibleEncodingMode } from '@/utils/steganography'
+
+const emojiOptions = ['👍', '🤓', '😎', '🫥', '🕵️', '🧠', '🔐', '🛰️']
+const modeOptions = [
+  { value: 'tags', label: 'Tags' },
+  { value: 'zero-width-binary', label: 'Zero-width' },
+  { value: 'variation-selectors', label: 'VS Bytes' },
+  { value: 'variation-selectors-nibbles', label: 'VS Nibbles' },
+  { value: 'variation-selectors-legacy', label: 'VS Legacy' },
+] as const
+
+const modeMeta: Record<
+  InvisibleEncodingMode,
+  { title: string; description: string; recommended?: boolean }
+> = {
+  tags: {
+    title: 'Unicode Tags',
+    description: 'Fully invisible payload characters. Compact, but some systems may sanitize them.',
+  },
+  'zero-width-binary': {
+    title: 'Zero-width Binary',
+    description: 'Best for broad compatibility, but uses the most hidden characters per message.',
+  },
+  'variation-selectors': {
+    title: 'Variation Selectors (Bytes)',
+    description: 'Strong default for capacity and stealth. Encodes UTF-8 bytes into selector code points.',
+    recommended: true,
+  },
+  'variation-selectors-nibbles': {
+    title: 'Variation Selectors (Nibbles)',
+    description: 'More granular 4-bit encoding. Useful for experimentation, but longer than byte mode.',
+  },
+  'variation-selectors-legacy': {
+    title: 'Variation Selectors (Legacy)',
+    description: 'Compatibility mode for older selector mappings and prior generated payloads.',
+  },
+}
+
+export interface EmojiSmugglingCipherKey {
+  coverText: string
+  encodingMode: InvisibleEncodingMode
+  interleave: boolean
+}
+
+interface Props {
+  cipherKey: EmojiSmugglingCipherKey
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  cipherKey: () => ({
+    coverText: '👍',
+    encodingMode: 'variation-selectors',
+    interleave: false,
+  }),
+})
+
+const emit = defineEmits<{
+  'update:cipherKey': [cipherKey: EmojiSmugglingCipherKey]
+}>()
+
+const localCoverText = computed({
+  get: () => props.cipherKey.coverText,
+  set: (coverText: string) => {
+    emit('update:cipherKey', {
+      ...props.cipherKey,
+      coverText,
+    })
+  },
+})
+
+const localEncodingMode = computed({
+  get: () => props.cipherKey.encodingMode,
+  set: (encodingMode: InvisibleEncodingMode) => {
+    emit('update:cipherKey', {
+      ...props.cipherKey,
+      encodingMode,
+    })
+  },
+})
+
+const localInterleave = computed({
+  get: () => props.cipherKey.interleave,
+  set: (interleave: boolean) => {
+    emit('update:cipherKey', {
+      ...props.cipherKey,
+      interleave,
+    })
+  },
+})
+
+const currentMode = computed(() => modeMeta[localEncodingMode.value])
+</script>
+
+<style scoped>
+@import '@/assets/cipher-key.css';
+
+.mode-help {
+  background: rgba(0, 255, 65, 0.05);
+  border: 1px solid rgba(0, 255, 65, 0.16);
+  border-radius: 10px;
+  margin-top: 0.4rem;
+  padding: 0.7rem 0.85rem;
+}
+
+.mode-help-header {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: space-between;
+}
+
+.mode-help-title {
+  color: var(--cryptotron-text-primary);
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+.mode-badge {
+  background: rgba(0, 255, 65, 0.14);
+  border: 1px solid rgba(0, 255, 65, 0.25);
+  border-radius: 999px;
+  color: var(--cryptotron-neon-green);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  padding: 0.16rem 0.55rem;
+  text-transform: uppercase;
+}
+
+.mode-help-copy {
+  color: var(--cryptotron-text-primary);
+  font-size: 0.88rem;
+  line-height: 1.45;
+  margin: 0.45rem 0 0;
+  opacity: 0.88;
+}
+
+.emoji-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.emoji-chip {
+  border: 1px solid rgba(0, 255, 65, 0.25);
+  border-radius: 999px;
+  background: rgba(0, 255, 65, 0.08);
+  color: inherit;
+  cursor: pointer;
+  font-size: 1.1rem;
+  line-height: 1;
+  padding: 0.5rem 0.75rem;
+}
+
+.emoji-chip.secondary {
+  font-size: 0.95rem;
+}
+
+.checkbox-control {
+  margin-top: 0.25rem;
+}
+
+.checkbox-label {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.5rem;
+}
+
+textarea.cipher-input {
+  resize: vertical;
+}
+</style>

--- a/src/views/AcrosticsView.vue
+++ b/src/views/AcrosticsView.vue
@@ -1,23 +1,34 @@
 <script setup lang="ts">
 import CipherCard from '@/components/CipherCard.vue'
+import KeyAcrostic, {
+  type AcrosticCipherKey,
+  type AcrosticMode,
+} from '@/components/keys/KeyAcrostic.vue'
 import CipherOutput from '@/components/CipherOutput.vue'
 import { computed, ref, watch } from 'vue'
 import { generateAcrostic } from '@/utils/text-gen'
 
-type AcrosticMode = 'acrostic' | 'telestic' | 'compound'
 const ACROSTIC_MODES: AcrosticMode[] = ['acrostic', 'telestic', 'compound']
 
-const acrosticMode = ref<AcrosticMode>('acrostic')
+const defaultAcrosticKey = (): AcrosticCipherKey => ({
+  coverText: '',
+  mode: 'acrostic',
+})
+
 const secretMessage = ref('')
-const acrosticKey = ref({ coverText: '' })
+const acrosticKey = ref<AcrosticCipherKey>(defaultAcrosticKey())
 
 const coverText = computed({
   get: () => acrosticKey.value.coverText ?? '',
   set: (value: string) => {
-    acrosticKey.value = {
-      ...acrosticKey.value,
-      coverText: value,
-    }
+    acrosticKey.value = { ...acrosticKey.value, coverText: value }
+  },
+})
+
+const acrosticMode = computed<AcrosticMode>({
+  get: () => acrosticKey.value.mode ?? 'acrostic',
+  set: (value) => {
+    acrosticKey.value = { ...acrosticKey.value, mode: value }
   },
 })
 
@@ -106,7 +117,7 @@ const handleAcrosticNormalModeKey = (key: string, activeTab: string) => {
     :decrypt-algorithm="() => acrosticDecrypt"
     :normal-mode-key-handler="handleAcrosticNormalModeKey"
     :on-encrypt-input-change="(val: string) => { secretMessage = val; coverText = ''; }"
-    :on-encrypt-clear="() => { secretMessage = ''; coverText = ''; }"
+    :on-encrypt-clear="() => { secretMessage = ''; acrosticKey = defaultAcrosticKey(); }"
     v-model:cipher-key="acrosticKey"
   >
     <template #theory>
@@ -213,18 +224,8 @@ const handleAcrosticNormalModeKey = (key: string, activeTab: string) => {
 
     <template #cipherKey>
       <div class="control-group">
-        <label class="control-label">Position Mode (m)</label>
-        <div class="mode-selector">
-          <button
-            v-for="m in ACROSTIC_MODES"
-            :key="m"
-            class="cipher-button"
-            :class="{ active: acrosticMode === m }"
-            @click="acrosticMode = m"
-          >
-            {{ m.charAt(0).toUpperCase() + m.slice(1) }}
-          </button>
-        </div>
+        <label class="control-label">Configuration</label>
+        <KeyAcrostic v-model:cipher-key="acrosticKey" />
       </div>
     </template>
 

--- a/src/views/BaconView.vue
+++ b/src/views/BaconView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import CipherCard from '@/components/CipherCard.vue'
+import KeyBacon, { type BaconCipherKey } from '@/components/keys/KeyBacon.vue'
 import CipherOutput from '@/components/CipherOutput.vue'
 import { computed, ref } from 'vue'
 import {
@@ -11,18 +12,26 @@ import {
 } from '@/utils/steganography'
 import { generateBaconCover } from '@/utils/text-gen'
 
-const baconCoverKey = ref({ coverText: '' })
+const defaultBaconKey = (): BaconCipherKey => ({
+  coverText: '',
+  exportMode: 'html',
+})
+
+const baconCoverKey = ref<BaconCipherKey>(defaultBaconKey())
 const secretMessage = ref('')
 const encodedInput = ref('')
-const exportMode = ref<'html' | 'markdown'>('html')
 
 const coverText = computed({
   get: () => baconCoverKey.value.coverText ?? '',
   set: (value: string) => {
-    baconCoverKey.value = {
-      ...baconCoverKey.value,
-      coverText: value,
-    }
+    baconCoverKey.value = { ...baconCoverKey.value, coverText: value }
+  },
+})
+
+const exportMode = computed({
+  get: () => baconCoverKey.value.exportMode ?? 'html',
+  set: (value: 'html' | 'markdown') => {
+    baconCoverKey.value = { ...baconCoverKey.value, exportMode: value }
   },
 })
 
@@ -35,7 +44,6 @@ const handleGenerateCover = () => {
   coverText.value = generateBaconCover(bitLength.value)
   if (secretMessage.value) {
     updatePreview()
-    updateActiveExport()
   }
 }
 
@@ -77,16 +85,12 @@ const extracted = computed(() => {
   }
 })
 
-const activeExport = ref('')
-
-const updateActiveExport = () => {
-  activeExport.value =
-    exportMode.value === 'html' ? toHtmlSnippet(preview.value) : toMarkdown(preview.value)
-}
+const activeExport = computed(() =>
+  exportMode.value === 'html' ? toHtmlSnippet(preview.value) : toMarkdown(preview.value),
+)
 
 const toggleExportMode = () => {
   exportMode.value = exportMode.value === 'html' ? 'markdown' : 'html'
-  updateActiveExport()
 }
 
 const handleBaconNormalModeKey = (key: string, activeTab: string) => {
@@ -113,7 +117,6 @@ const handleBaconNormalModeKey = (key: string, activeTab: string) => {
 const baconEncrypt = (input: string) => {
   secretMessage.value = input
   updatePreview()
-  updateActiveExport()
   return activeExport.value
 }
 
@@ -134,8 +137,8 @@ const baconDecrypt = (input: string) => {
     :decrypt-algorithm="() => baconDecrypt"
     :encrypt-output-override="() => activeExport"
     :normal-mode-key-handler="handleBaconNormalModeKey"
-    :on-encrypt-input-change="(val: string) => { secretMessage = val; preview = []; activeExport = ''; }"
-    :on-encrypt-clear="() => { secretMessage = ''; coverText = ''; preview = []; activeExport = ''; }"
+    :on-encrypt-input-change="(val: string) => { secretMessage = val; preview = []; }"
+    :on-encrypt-clear="() => { secretMessage = ''; baconCoverKey = defaultBaconKey(); preview = []; }"
     :encrypt-feedback="lengthError"
     v-model:cipher-key="baconCoverKey"
   >
@@ -238,22 +241,10 @@ const baconDecrypt = (input: string) => {
 
     <template #cipherKey="{ panel }">
       <div v-if="panel !== 'decrypt'" class="control-group">
-        <div class="bacon-preview-header">
-          <label class="control-label">Cover Text</label>
-          <button
-            class="cipher-button bacon-secondary-button"
-            type="button"
-            @click="handleGenerateCover"
-            :disabled="bitLength === 0"
-          >
-            Generate Cover (g)
-          </button>
-        </div>
-        <textarea
-          v-model="coverText"
-          rows="6"
-          class="cipher-textarea cipher-input"
-          placeholder="Enter the visible carrier text or generate one..."
+        <KeyBacon
+          v-model:cipher-key="baconCoverKey"
+          :generate-disabled="bitLength === 0"
+          @generate-cover="handleGenerateCover"
         />
       </div>
     </template>
@@ -274,15 +265,6 @@ const baconDecrypt = (input: string) => {
         <div>
           <div class="bacon-preview-header">
             <label class="control-label">Export Output</label>
-            <div class="bacon-export-actions">
-              <button
-                class="cipher-button bacon-secondary-button"
-                type="button"
-                @click="toggleExportMode"
-              >
-                {{ exportMode === 'html' ? 'Switch to Markdown (m)' : 'Switch to HTML (m)' }}
-              </button>
-            </div>
           </div>
           <CipherOutput :label="exportMode.toUpperCase()" :text="activeExport" />
         </div>
@@ -304,12 +286,6 @@ const baconDecrypt = (input: string) => {
   gap: 1rem;
   flex-wrap: wrap;
   margin-bottom: 0.5rem;
-}
-
-.bacon-export-actions {
-  display: flex;
-  gap: 0.75rem;
-  flex-wrap: wrap;
 }
 
 .bacon-preview {

--- a/src/views/BuilderView.vue
+++ b/src/views/BuilderView.vue
@@ -16,7 +16,11 @@ import {
   defaultEdges,
   defaultNodes,
 } from '@/components/builder/constants'
-import { willCreateCycle, GraphAnalyzer } from '@/components/builder/utils'
+import {
+  validateSteganographyTopology,
+  willCreateCycle,
+  GraphAnalyzer,
+} from '@/components/builder/utils'
 import AddNodeModal from '@/components/builder/ModalAddNode.vue'
 import EditNodeModal from '@/components/builder/ModalEditNode.vue'
 import SaveGraphModal from '@/components/builder/ModalSaveGraph.vue'
@@ -76,6 +80,11 @@ const closeAddNodeModal = () => {
   }
 }
 
+const rejectBuilderAction = (message: string) => {
+  console.warn(message)
+  alert(message)
+}
+
 const handleAddNode = (nodeData: { label: string; type: string }) => {
   const selectedCipher = availableCiphers.find((c) => c.type === nodeData.type)
   if (!selectedCipher) return
@@ -102,6 +111,12 @@ const handleAddNode = (nodeData: { label: string; type: string }) => {
       x: 50 + (existingNodes.length % 4) * 150,
       y: maxY + 120,
     },
+  }
+
+  const topologyError = validateSteganographyTopology([...existingNodes, newNode], getEdges.value)
+  if (topologyError) {
+    rejectBuilderAction(topologyError)
+    return
   }
 
   addNodes([newNode])
@@ -175,19 +190,24 @@ onNodeDoubleClick(({ event, node }) => {
 })
 
 const validateNewEdge = (
+  existingNodes: Node[],
   existingEdges: Edge[],
   newEdge: Connection,
   oldEdge: Partial<Edge> = { source: '', target: '' },
 ): boolean => {
   console.debug('Validating new edge', newEdge, oldEdge)
+  const candidateEdges = oldEdge.id
+    ? existingEdges.filter((edge) => edge.id !== oldEdge.id)
+    : existingEdges
+
   /* */
-  if (existingEdges.some((e) => e.source === newEdge.source)) {
+  if (candidateEdges.some((e) => e.source === newEdge.source)) {
     if (oldEdge.source !== newEdge.source) {
       console.warn(`Node ${newEdge.source} already has an edge from it`)
       return false
     }
   }
-  if (existingEdges.some((e) => e.target === newEdge.target)) {
+  if (candidateEdges.some((e) => e.target === newEdge.target)) {
     if (oldEdge.target !== newEdge.target) {
       console.warn(`Node ${newEdge.target} already has an edge to it`)
       return false
@@ -195,8 +215,21 @@ const validateNewEdge = (
   }
   /* */
 
-  if (willCreateCycle(existingEdges, newEdge)) {
+  if (willCreateCycle(candidateEdges, newEdge)) {
     console.warn(`Connecting Node ${newEdge.source} to Node ${newEdge.target} will create a loop`)
+    return false
+  }
+
+  const topologyError = validateSteganographyTopology(existingNodes, [
+    ...candidateEdges,
+    {
+      source: newEdge.source,
+      target: newEdge.target,
+    } as Edge,
+  ])
+
+  if (topologyError) {
+    console.warn(topologyError)
     return false
   }
   /* */
@@ -207,8 +240,14 @@ onConnect((connection) => {
   console.debug('On Connect', connection)
   /* */
   const existing = getEdges.value
+  const currentNodes = getNodes.value
   console.debug('Existing edges', existing)
-  if (!validateNewEdge(existing, connection)) {
+  if (!validateNewEdge(currentNodes, existing, connection)) {
+    const topologyError = validateSteganographyTopology(currentNodes, [
+      ...existing,
+      { source: connection.source, target: connection.target } as Edge,
+    ])
+    if (topologyError) rejectBuilderAction(topologyError)
     return
   }
   /* */
@@ -224,8 +263,14 @@ onEdgeUpdate(({ connection, edge }) => {
   console.debug('On Edge Update', connection, edge)
   /* */
   const existing = getEdges.value
+  const currentNodes = getNodes.value
   console.debug('Existing edges', existing)
-  if (!validateNewEdge(existing, connection, edge)) {
+  if (!validateNewEdge(currentNodes, existing, connection, edge)) {
+    const topologyError = validateSteganographyTopology(currentNodes, [
+      ...existing.filter((currentEdge) => currentEdge.id !== edge.id),
+      { source: connection.source, target: connection.target } as Edge,
+    ])
+    if (topologyError) rejectBuilderAction(topologyError)
     return
   }
   /* */
@@ -345,6 +390,8 @@ const handleLoadGraph = (cipherFile: File) => {
             decryptAlgorithm: cipherData.decryptAlgorithm,
             crackAlgorithm: cipherData.crackAlgorithm,
             cipherKeyComponent: cipherData.cipherKeyComponent,
+            category: cipherData.category,
+            placement: cipherData.placement,
           },
         }
       })
@@ -359,6 +406,12 @@ const handleLoadGraph = (cipherFile: File) => {
         }
       })
       console.debug('Enhanced edges from cipher file data', enhancedEdges)
+
+      const topologyError = validateSteganographyTopology(enhancedNodes, enhancedEdges)
+      if (topologyError) {
+        rejectBuilderAction(topologyError)
+        return
+      }
 
       nodes.value = [...enhancedNodes]
       edges.value = [...enhancedEdges]
@@ -422,6 +475,12 @@ const getTraversedNodedata = () => {
   const currentNodes = getNodes.value
   console.debug('Current edges', currentEdges)
   console.debug('Current nodes', currentNodes)
+
+  const topologyError = validateSteganographyTopology(currentNodes, currentEdges)
+  if (topologyError) {
+    rejectBuilderAction(topologyError)
+    return
+  }
 
   const graph = new GraphAnalyzer(currentEdges)
   console.log('Found root nodes', graph.getRootNodes())

--- a/src/views/BuilderView.vue
+++ b/src/views/BuilderView.vue
@@ -194,7 +194,7 @@ const validateNewEdge = (
   existingEdges: Edge[],
   newEdge: Connection,
   oldEdge: Partial<Edge> = { source: '', target: '' },
-): boolean => {
+): string | null => {
   console.debug('Validating new edge', newEdge, oldEdge)
   const candidateEdges = oldEdge.id
     ? existingEdges.filter((edge) => edge.id !== oldEdge.id)
@@ -203,21 +203,18 @@ const validateNewEdge = (
   /* */
   if (candidateEdges.some((e) => e.source === newEdge.source)) {
     if (oldEdge.source !== newEdge.source) {
-      console.warn(`Node ${newEdge.source} already has an edge from it`)
-      return false
+      return `Node ${newEdge.source} already has an outgoing edge.`
     }
   }
   if (candidateEdges.some((e) => e.target === newEdge.target)) {
     if (oldEdge.target !== newEdge.target) {
-      console.warn(`Node ${newEdge.target} already has an edge to it`)
-      return false
+      return `Node ${newEdge.target} already has an incoming edge.`
     }
   }
   /* */
 
   if (willCreateCycle(candidateEdges, newEdge)) {
-    console.warn(`Connecting Node ${newEdge.source} to Node ${newEdge.target} will create a loop`)
-    return false
+    return `Connecting Node ${newEdge.source} to Node ${newEdge.target} will create a loop.`
   }
 
   const topologyError = validateSteganographyTopology(existingNodes, [
@@ -229,11 +226,10 @@ const validateNewEdge = (
   ])
 
   if (topologyError) {
-    console.warn(topologyError)
-    return false
+    return topologyError
   }
   /* */
-  return true
+  return null
 }
 
 onConnect((connection) => {
@@ -242,12 +238,9 @@ onConnect((connection) => {
   const existing = getEdges.value
   const currentNodes = getNodes.value
   console.debug('Existing edges', existing)
-  if (!validateNewEdge(currentNodes, existing, connection)) {
-    const topologyError = validateSteganographyTopology(currentNodes, [
-      ...existing,
-      { source: connection.source, target: connection.target } as Edge,
-    ])
-    if (topologyError) rejectBuilderAction(topologyError)
+  const rejectionReason = validateNewEdge(currentNodes, existing, connection)
+  if (rejectionReason) {
+    rejectBuilderAction(rejectionReason)
     return
   }
   /* */
@@ -265,12 +258,9 @@ onEdgeUpdate(({ connection, edge }) => {
   const existing = getEdges.value
   const currentNodes = getNodes.value
   console.debug('Existing edges', existing)
-  if (!validateNewEdge(currentNodes, existing, connection, edge)) {
-    const topologyError = validateSteganographyTopology(currentNodes, [
-      ...existing.filter((currentEdge) => currentEdge.id !== edge.id),
-      { source: connection.source, target: connection.target } as Edge,
-    ])
-    if (topologyError) rejectBuilderAction(topologyError)
+  const rejectionReason = validateNewEdge(currentNodes, existing, connection, edge)
+  if (rejectionReason) {
+    rejectBuilderAction(rejectionReason)
     return
   }
   /* */

--- a/src/views/EmojiSmugglingView.vue
+++ b/src/views/EmojiSmugglingView.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import CipherCard from '@/components/CipherCard.vue'
+import KeyEmojiSmuggling, {
+  type EmojiSmugglingCipherKey,
+} from '@/components/keys/KeyEmojiSmuggling.vue'
 import CipherOutput from '@/components/CipherOutput.vue'
 import { computed, ref, watch, onUnmounted } from 'vue'
 import {
@@ -9,19 +12,33 @@ import {
   type InvisibleEncodingMode,
 } from '@/utils/steganography'
 
-const emojiOptions = ['👍', '🤓', '😎', '🫥', '🕵️', '🧠', '🔐', '🛰️']
-const tagsKey = ref({ coverText: '👍' })
+const defaultTagsKey = (): EmojiSmugglingCipherKey => ({
+  coverText: '👍',
+  encodingMode: 'variation-selectors',
+  interleave: false,
+})
+
+const tagsKey = ref<EmojiSmugglingCipherKey>(defaultTagsKey())
 const revealMode = ref(true)
-const encodingMode = ref<InvisibleEncodingMode>('variation-selectors')
-const interleave = ref(false)
 
 const coverText = computed({
   get: () => tagsKey.value.coverText ?? '',
   set: (value: string) => {
-    tagsKey.value = {
-      ...tagsKey.value,
-      coverText: value,
-    }
+    tagsKey.value = { ...tagsKey.value, coverText: value }
+  },
+})
+
+const encodingMode = computed<InvisibleEncodingMode>({
+  get: () => tagsKey.value.encodingMode ?? 'variation-selectors',
+  set: (value) => {
+    tagsKey.value = { ...tagsKey.value, encodingMode: value }
+  },
+})
+
+const interleave = computed({
+  get: () => tagsKey.value.interleave ?? false,
+  set: (value: boolean) => {
+    tagsKey.value = { ...tagsKey.value, interleave: value }
   },
 })
 
@@ -110,20 +127,10 @@ const setSecretMessage = (value: string) => {
   secretMessage.value = value
 }
 
-const useEmojiCarrier = (emoji: string) => {
-  coverText.value = emoji
-}
-
-const appendEmojiCarrier = (emoji: string) => {
-  coverText.value = `${coverText.value}${emoji}`
-}
-
 const clearEncryptState = () => {
   secretMessage.value = ''
   revealMode.value = true
-  coverText.value = '👍'
-  encodingMode.value = 'variation-selectors'
-  interleave.value = false
+  tagsKey.value = defaultTagsKey()
   manualEncodedOutput.value = ''
   manualEncodingWarning.value = ''
 }
@@ -237,59 +244,9 @@ const tagsDecrypt = (input: string) => {
     </template>
 
     <template #cipherKey>
-      <div class="control-grid">
-        <div class="control-group">
-          <label class="control-label">
-            Encoding Mode
-            <span class="label-hint">(m)</span>
-          </label>
-          <select v-model="encodingMode" class="cipher-select">
-            <option value="tags">Unicode Tags</option>
-            <option value="zero-width-binary">Zero-width Binary</option>
-            <option value="variation-selectors">Variation Selectors (UTF-8 bytes)</option>
-            <option value="variation-selectors-nibbles">Variation Selectors (4-bit nibbles)</option>
-            <option value="variation-selectors-legacy">Variation Selectors (Legacy A=1)</option>
-          </select>
-        </div>
-
-        <div class="control-group checkbox-group">
-          <label class="mode-option">
-            <input v-model="interleave" type="checkbox" />
-            Interleave Payload
-          </label>
-        </div>
-      </div>
-
       <div class="control-group">
-        <label class="control-label">Carrier Emoji / Cover Text</label>
-        <div class="emoji-picker">
-          <button
-            v-for="emoji in emojiOptions"
-            :key="emoji"
-            type="button"
-            class="emoji-chip"
-            @click="useEmojiCarrier(emoji)"
-          >
-            {{ emoji }}
-          </button>
-        </div>
-        <div class="emoji-picker">
-          <button
-            v-for="emoji in emojiOptions"
-            :key="`${emoji}-append`"
-            type="button"
-            class="emoji-chip secondary"
-            @click="appendEmojiCarrier(emoji)"
-          >
-            +{{ emoji }}
-          </button>
-        </div>
-        <textarea
-          v-model="coverText"
-          rows="3"
-          class="cipher-textarea cipher-input"
-          placeholder="Paste your own emoji or custom carrier text here..."
-        />
+        <label class="control-label">Configuration</label>
+        <KeyEmojiSmuggling v-model:cipher-key="tagsKey" />
       </div>
     </template>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three steganography ciphers: Bacon, Emoji Smuggling, and Acrostic
  * New key configuration UIs for Bacon, Emoji Smuggling, and Acrostic; related views switched to use these components
  * Builder enforces steganography topology rules and rejects invalid graph edits or imports

* **Tests**
  * Added tests for steganography validation and cipher input handling

* **Chores**
  * Package version bumped to 0.4.1

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jabez007/cryptotron.vue/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->